### PR TITLE
parse-config abnf作成

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -147,18 +147,6 @@ http {
   send_timeout 1000s;
 }
 ```
-- keepalive_time
-  - syntax: positive-number[ ms / s / m / h ]
-  - default: 1h
-  - context: **http**, **server**, **location**
-  - 重複可否: yes 同context内での重複はno
-
-```
-http {
-  keepalive_time 2h;
-}
-```
-
 
 - keepalive_timeout
   - syntax: positive-number[ ms / s / m / h ]

--- a/docs/config.md
+++ b/docs/config.md
@@ -1,0 +1,304 @@
+# .config仕様書
+
+## 言葉の定義
+- context
+  - 基本的にcontextは`{}`で囲まれる
+  - main-contextのみ`{}`で囲まれない
+  - contextのレベル: 高い順
+    - main
+    - http: **main-context** に一つだけ存在する
+    - events: **main-context** に一つだけ存在する
+    - server: **http-context** に複数存在可
+    - location: **server-context** に複数存在可
+    - limit_except: **location-context** に複数存在可
+- directive
+  - contextの中に表記される
+  - セミコロン`;`で終わる
+  - 同じdirectiveは複数存在可
+ 
+## context
+- contextは`{}`で囲まれる
+```
+# main-context
+http {
+  # http-context
+  server {
+    # server-context
+    location / { 
+      # location-context
+      limit_except GET {
+        # limit_except-context
+       }
+     }
+  server {
+    # server-context
+    location / { 
+      # location-context
+      limit_except PUT {
+        # limit_except-context
+       }
+     }
+  }
+  server {
+  }
+}
+
+events {
+  # events-context
+}
+```
+
+## directive
+- error_log
+  - syntax: file
+  - default: error_log logs/error.log error;
+  - context: **main**, **http**, **server**, **location**
+  - 重複可否: yes
+    - 重複する場合、より低いレベルのcontextがerror_logの対象となる
+    - 同じcontextレベルで複数ある場合、それら全てにエラーが書き込まれる
+  - 出力レベル: 指定されたレベル以上を出力（以下レベル低い順）
+    - warn
+    - error
+    - emerg 
+  - エラー処理
+    - pathのディレクトリが存在しない場合、エラーを出力して終了: error01<br> ファイルが存在しない場合は作成
+    - fileのpermissionがない場合（write権限さえあればいい？）は、エラーを出力して終了: error02
+    - invalid log level: error03
+
+```
+example00
+
+error_log	/Users/tatyu/Documents/nginx/logs/error.log emerg;
+http {
+  server {
+   location / {
+      error_log	/Users/tatyu/Documents/nginx/logs/index_error.log;
+    }
+  location /styles/ {
+      error_log	/Users/tatyu/Documents/nginx/logs/styles_error.log;
+  }
+  server {
+    error_log	/Users/tatyu/Documents/nginx/logs/index_error.log;
+  }
+}
+```
+
+- worker_connections
+  - syntax:  positive-number
+  - default: 512
+  - context: **events**
+  - 重複可否: no
+  - エラー処理
+    - 0 エラーを出力して終了: error01
+    - negative number エラーを出力して終了: error02
+    - invalid number エラーを出力して終了: error03
+
+```
+example00
+
+events {
+  worker_connections 1000;
+}
+```
+
+- use
+  - syntax: method
+  - default: -
+  - context: **events**
+  - 重複可否: no
+
+```
+events {
+  use epoll;
+}
+```
+```
+events {
+  use kqueue;
+}
+```
+
+- listen
+  - syntax: address | port, address:port
+  - default: 127.0.0.1:80, 127.0.0.1:8000
+  - context: **server**
+  - 重複可否: yes ただし同じcontext内には一つのみ
+ 
+```
+example00
+
+http {
+  server {
+     listen 8080;
+     listen 80;
+     listen [::]:10;
+   }
+}
+```
+
+- server_name
+  - syntax: name
+  - default: ""
+  - context: **server**
+  - 重複可否: yes
+    - 重複する場合の挙動は不明
+```
+http {
+  server {
+    server_name www.tachu.com tachu.com;
+  }
+}
+```
+
+- send_timeout
+  - syntax: positive-number[ ms / s / m / h ]
+  - default: 60s
+  - context: **http**, **server**, **location**
+  - 重複可否: no
+
+```
+exapmle00
+
+http {
+  send_timeout 1000s;
+}
+```
+- keepalive_time
+  - syntax: positive-number[ ms / s / m / h ]
+  - default: 1h
+  - context: **http**, **server**, **location**
+  - 重複可否: yes 同context内での重複はno
+
+```
+http {
+  keepalive_time 2h;
+}
+```
+
+
+- keepalive_timeout
+  - syntax: positive-number[ ms / s / m / h ]
+  - default: 60s
+  - context: **http**, **server**, **location**
+  - 重複可否: yes 同context内での重複はno
+
+```
+http {
+  keepalive_timeout 2m;
+}
+```
+
+- error_page
+  - syntax: code uri
+  - default: -
+  - context: **http**, **server**, **location**
+  - 重複可否: yes
+    - 同じcontextレベルで重複した場合、先に設定してものが適応される
+    - contextレベルが低い設定が優先される
+
+```
+http {
+  root /Users/me/server;
+  error_page 403 404 /error/error.html;
+  server / {}
+  server /user {
+    error_page 403 404 /error/error2.html;  
+  }
+}
+```
+
+- root
+  - syntax: path
+  - default: html
+  - context: **http**, **server**, **location**
+  - 重複可否: yes 同context内での重複はno
+    - contextレベルが低い設定が優先される
+
+```
+http {
+  root /Users/name/server;
+  
+  location / {
+    root /Users/name/server/profile;
+  }
+
+}
+```
+
+- client_max_body_size
+  - syntax: size[k / K / m / M]
+  - default: 1m
+  - context: **http**, **server**, **location**
+  - 重複可否: yes 同context内での重複はno
+    - contextレベルが低い設定が優先される
+
+```
+http {
+  client_max_body_size 2m;
+}
+```
+
+- allow
+  - syntax: address | all
+  - default: -
+  - context: **http**, **server**, **location**, **limit_except**
+  - 重複可否: yes
+
+- deny
+  - syntax: address | all
+  - default: -
+  - context: **http**, **server**, **location**, **limit_except**
+  - 重複可否: yes
+
+```
+http {
+  allow 192.168.1.1/24;
+  deny all;
+}
+```
+
+- autoindex
+  - syntax: on | off
+  - default: off
+  - context: **http**, **server**, **location**
+  - 重複可否: yes 同context内での重複はno
+
+```
+http {
+  server {
+    autoindex on;
+  }
+}
+```
+
+- index
+  - syntax: file
+  - default: index.html
+  - context: **http**, **server**, **location**
+  - 重複可否: yes
+    - 重複している場合、先に指定されたものが優先される
+
+```
+http {
+  server {
+    index index.html;
+  }
+}
+```
+
+- return
+  - syntax: code | code URL | URL
+  - default: -
+  - context: **server**, **location**
+  - 重複可否: yes
+    - 重複している場合、先に指定されたものが優先される
+
+```
+http {
+  server {
+    location /redirect/ {
+      return 301 https://google.com;
+    }
+  }
+}
+```

--- a/docs/config.md
+++ b/docs/config.md
@@ -273,7 +273,7 @@ http {
 - return
   - syntax: code | code URL | URL
   - default: -
-  - context: **server**, **location**
+  - context: **location**
   - 重複可否: yes
     - 重複している場合、先に指定されたものが優先される
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -65,9 +65,8 @@ events {
     - fileのpermissionがない場合（write権限さえあればいい？）は、エラーを出力して終了: error02
     - invalid log level: error03
 
-```
-example00
 
+```
 error_log	/Users/tatyu/Documents/nginx/logs/error.log emerg;
 http {
   server {
@@ -94,8 +93,6 @@ http {
     - invalid number エラーを出力して終了: error03
 
 ```
-example00
-
 events {
   worker_connections 1000;
 }
@@ -125,8 +122,6 @@ events {
   - 重複可否: yes ただし同じcontext内には一つのみ
  
 ```
-example00
-
 http {
   server {
      listen 8080;

--- a/docs/config.md
+++ b/docs/config.md
@@ -55,16 +55,11 @@ events {
   - context: **main**, **http**, **server**, **location**
   - 重複可否: yes
     - 重複する場合、より低いレベルのcontextがerror_logの対象となる
-    - 同じcontextレベルで複数ある場合、それら全てにエラーが書き込まれる
+    - 同じcontextレベルで複数ある場合、それら全てにログが書き込まれる
   - 出力レベル: 指定されたレベル以上を出力（以下レベル低い順）
     - warn
     - error
     - emerg 
-  - エラー処理
-    - pathのディレクトリが存在しない場合、エラーを出力して終了: error01<br> ファイルが存在しない場合は作成
-    - fileのpermissionがない場合（write権限さえあればいい？）は、エラーを出力して終了: error02
-    - invalid log level: error03
-
 
 ```
 error_log	/Users/tatyu/Documents/nginx/logs/error.log emerg;
@@ -87,10 +82,6 @@ http {
   - default: 512
   - context: **events**
   - 重複可否: no
-  - エラー処理
-    - 0 エラーを出力して終了: error01
-    - negative number エラーを出力して終了: error02
-    - invalid number エラーを出力して終了: error03
 
 ```
 events {
@@ -152,8 +143,6 @@ http {
   - 重複可否: no
 
 ```
-exapmle00
-
 http {
   send_timeout 1000s;
 }

--- a/docs/webserv_conf.abnf
+++ b/docs/webserv_conf.abnf
@@ -3,16 +3,19 @@ alpha = "a" / "b" / "c" / "d" / "e" / "f" / "g" / "h" / "i" / "j" / "k" / "l" / 
 DIGIT	= "0" / "1" / "2" / "3" / "4" / "5" / "6" / "7" / "8" / "9"
 hexdig = DIGIT / "A" / "B" / "C" / "D" / "E" / "F" / "a" / "b" / "c" / "d" / "e" / "f"
 WS	= " " / "\t" / NEWLINE ;スペース、水平タブまたは改行
-OWS	= *(WS) optional ws
+OWS	= *(WS) ;optional ws
 h16 = 1*4HEXDIG
 NEWLINE	= "\n"
 alphadigit = ALPHA / alpha / DIGIT ;アルファベットまたは数字
 END_DIRECTIVE	= ";"
 
-http	= "http" OWS "{" OWS server-directive OWS "}" END_DIRECTIVE
+main	= [http] [errorlog]
+http	= 1("http" OWS "{" OWS server-directive OWS "}") ;webサーバ全体の設定
+errorlog	= path WS level OWS END_DIRECTIVE
+level	= "debug" / "info" / "notice" / "warn" / "error" / "crit" / "alert" / "emerg" ;指定したlevel以上を出力する
 
-server-directive	= "server" OWS "{" serverconfig "}" END_DIRECTIVE
-serverconfig	= listen-directive END_DIRECTIVE
+server-directive	= "server" OWS "{" [serverconfig] "}" ;{}の中が空も許容する
+serverconfig	= [listen-directive] [server-name] [location-directive]
 
 listen-directive	= "listen" WS address-port
 address-port	= address [ ":" port ] / port ;デフォルトaddress:0.0.0.0 デフォルトport:80
@@ -33,14 +36,22 @@ ls32	= ( h16 ":" h16 ) / IPv4address ;()はグループを示すので、右を�
 h16 = 1*4(HEXDIG) ;HEXDIGが1回から4回まで続く
 port	= 1*(DIGIT)  ;少なくとも1回のDIGITが続くシーケンス
 
-server_name	= "server_name" WS alphadigit END_DIRECTIVE
+server-name	= "server_name" 1*(WS alphadigit) END_DIRECTIVE ; 
 
-location	= END_DIRECTIVE
-path	= 
+location-directive	= "location" WS path "{" *[location-config] "}"END_DIRECTIVE
+location-config	= root-directive / keepalive-timeout / error-page-directive
+root-directive	= "root" WS path END_DIRECTIVE
+send-timeout	= "send_timeout" WS time-sec ;Default: 60s
+path	= "/" 1*(path-segment)
+path-segment	= 1*(ALPHA / DIGIT / "-" / "_") ["/"]
+keepalive-timeout	= "keepalive_timeout" time-sec ;Default: 75s
+time-sec	= DIGIT ["s"]
+client-max-body-size	= "client_max_body_size" WS size-mb END_DIRECTIVE ;Default:1m, size to 0 disables checking of client request body size-mb	= DIGIT ["m"] ; megabytes
 
 error-page-directive	= "error_page" WS error_codes [response] END_DIRECTIVE
 error-codes = error-code *(SP error-code) END_DIRECTIVE
 error_code	= 3(DIGIT) END_DIRECTIVE
-response	= "/"  / URL
+response	= path-to-file
+path-to-file	= path alphadigit
 
 client_max_body_size_directive	= "client_body_buffer_size" OWS DIGIT END_DIRECTIVE

--- a/docs/webserv_conf.abnf
+++ b/docs/webserv_conf.abnf
@@ -19,7 +19,8 @@ uri	= absolute-path ;表記は同じだが、uriはrootの後に追加される 
 path	= absolute-path / uri 
 file	= uri
 
-time	= DIGIT ["ms" / "s" / "m" / "h"]
+time	= 1*(DIGIT) ["ms" / "s" / "m" / "h"]
+size	= 1*(DIGIT) ["k" / "K" / "m" / "M"]
 url	= scheme "://" host
 scheme	= "http" / "https";
 host	= VCHAR
@@ -85,7 +86,7 @@ keepalive-timeout-directive	= "keepalive_timeout" time OWS END_DIRECTIVE;Default
 
 return-directive	= "return" WS status WS uri OWS END_DIRECTIVE ; redirectで使用
 
-client-max-body-size-directive	= "client_max_body_size" WS size-mb OWS END_DIRECTIVE ;Default:1m, size to 0 disables checking of client size-mb	= DIGIT ["m"] ; megabytes
+client-max-body-size-directive	= "client_max_body_size" WS size OWS END_DIRECTIVE ;Default:1m, size to 0 disables checking of client 
 
 error-page-directive	= "error_page" WS error-codes ["=" status] WS uri OWS END_DIRECTIVE
 error-codes = error-code *(SP error-code)

--- a/docs/webserv_conf.abnf
+++ b/docs/webserv_conf.abnf
@@ -10,15 +10,15 @@ alphadigit = ALPHA / alpha / DIGIT ;アルファベットまたは数字
 status	= 3(DIGIT)
 END_DIRECTIVE	= ";"
 
-main	= [http] [errorlog]
-http	= 1("http" OWS "{" OWS server-directive OWS "}") ;webサーバ全体の設定
-errorlog	= "error_log" WS path [WS level] OWS END_DIRECTIVE
+main	= [http-directive] [errorlog-directive]
+http-directive	= 1("http" OWS "{" OWS server-directive OWS "}") ;webサーバ全体の設定
+errorlog-directive	= "error_log" WS path [WS level] OWS END_DIRECTIVE
 level	= "debug" / "info" / "notice" / "warn" / "error" / "crit" / "alert" / "emerg" ;指定したlevel以上を出力する
 
-server-directive	= "server" OWS "{" [serverconfig] "}" ;{}の中が空も許容する
-serverconfig	= [listen-directive] [server-name] [location-directive]
+server-directive	= "server" OWS "{" OWS [serverconfig] OWS "}" ;{}の中が空も許容する
+serverconfig	= [listen-directive] [server-name-directive] [location-directive]
 
-listen-directive	= "listen" WS address-port
+listen-directive	= "listen" WS address-port OWS END_DIRECTIVE
 address-port	= address [ ":" port ] / port ;デフォルトaddress:0.0.0.0 デフォルトport:80
 address	=  * / localhost / ip-address
 ip-address = IPv4-address / IPv6-address
@@ -38,17 +38,18 @@ ls32	= ( h16 ":" h16 ) / IPv4address ;()はグループを示すので、右を�
 h16 = 1*4(HEXDIG) ;HEXDIGが1回から4回まで続く
 port	= 1*(DIGIT)  ;少なくとも1回のDIGITが続くシーケンス
 
-server-name	= "server_name" 1*(WS alphadigit) END_DIRECTIVE ; 
+server-name-directive	= "server_name" 1*(WS alphadigit) OWS END_DIRECTIVE 
 
-location-directive	= "location" WS path "{" OWS *[location-config] OWS "}"END_DIRECTIVE
+location-directive	= "location" WS path "{" OWS *[location-config] OWS "}"
 location-config	= root-directive
 				/ keepalive-timeout
 				/ error-page-directive 
 				/ return-directive
 				/ limit-except-directive
 				/ permission-directive
-				/ display-dir-list
-				/ index-file
+				/ display-dir-list-directive
+				/ index-file-directive
+				/ client-max-body-size-directive
 
 root-directive	= "root" WS path END_DIRECTIVE
 send-timeout	= "send_timeout" WS time-sec ;Default: 60s
@@ -62,11 +63,11 @@ uri	= scheme "://" host
 scheme	= "http" / "https";
 host	= alphadigit
 
-client-max-body-size	= "client_max_body_size" WS size-mb END_DIRECTIVE ;Default:1m, size to 0 disables checking of client request body size-mb	= DIGIT ["m"] ; megabytes
+client-max-body-size-directive	= "client_max_body_size" WS size-mb END_DIRECTIVE ;Default:1m, size to 0 disables checking of client request body size-mb	= DIGIT ["m"] ; megabytes
 
 error-page-directive	= "error_page" WS error_codes [response] END_DIRECTIVE
-error-codes = error-code *(SP error-code) END_DIRECTIVE
-error_code	= status END_DIRECTIVE
+error-codes = error-code *(SP error-code)
+error_code	= status
 response	= path-to-file
 path-to-file	= path alphadigit
 file	= alphadigit / path-to-file
@@ -79,9 +80,9 @@ ip-address	= ip-address "/" "0"-"32"
 limit-except-directive	= "limit_except" WS  method OWS "{" OWS *(permission-directive) OWS "}"
 method	= "GET" / "HEAD" / "PUT" / "DELETE" ;Allowing the GET method makes the HEAD method also allowed
 
-display-dir-list	= "autoindex" WS on-off
+display-dir-list-directive	= "autoindex" WS on-off PWS END_DIRECTIVE
 on-off	= "ON" / "OFF"
 
-index-file	= "index" WS 1*(file) ;リクエストがディレクトリ(/)に対するもののレスポンスを設定。複数のファイルが存在する場合左から順に探す
+index-file-directive	= "index" WS 1*(file) OWS END_DIRECTIVE;リクエストがディレクトリ(/)に対するもののレスポンスを設定。複数のファイルが存在する場合左から順に探す
 
-client_max_body_size_directive	= "client_body_buffer_size" OWS DIGIT END_DIRECTIVE
+client_max_body_size_directive	= "client_body_buffer_size" OWS DIGIT OWS END_DIRECTIVE

--- a/docs/webserv_conf.abnf
+++ b/docs/webserv_conf.abnf
@@ -54,7 +54,7 @@ errorlog-directive	= "error_log" WS file [WS level] OWS END_DIRECTIVE ;Default: 
 level	= "debug" / "info" / "notice" / "warn" / "error" / "crit" / "alert" / "emerg" ;指定したlevel以上を出力する
 
 server-context	= "server" OWS "{" OWS *(serverconfig) OWS "}" ;{}の中が空も許容する
-serverconfig	= [listen-directive] [server-name-directive] [location-directive]
+serverconfig	= [listen-directive] [server-name-directive] [location-context]
 
 listen-directive	= "listen" WS address-port OWS END_DIRECTIVE
 address-port	= address [ ":" port ] / port ;デフォルトaddress:0.0.0.0 デフォルトport:80
@@ -63,12 +63,12 @@ port	= 1*(DIGIT)  ;少なくとも1回のDIGITが続くシーケンス
 
 server-name-directive	= "server_name" 1*(WS VCHAR) OWS END_DIRECTIVE ; The first name becomes the primary server name
 
-location-directive	= "location" WS uri "{" OWS *[location-config] OWS "}"
+location-context	= "location" WS uri "{" OWS *[location-config] OWS "}"
 location-config	= root-directive
 				/ keepalive-timeout-directive
 				/ error-page-directive 
 				/ return-directive
-				/ limit-except-directive
+				/ limit-except-context
 				/ permission-directive
 				/ display-dir-list-directive
 				/ index-file-directive
@@ -91,7 +91,7 @@ permission-directive	= permission WS permission-target OWS END_DIRECTIVE
 permission-target	= IPv4-address "/" IPv4-subnetmask / IPv6-address "/" IPv6-prefix / all 
 permission	= "allow" / "deny"
 
-limit-except-directive	= "limit_except" WS  method OWS "{" OWS *(permission-directive) OWS "}"
+limit-except-context	= "limit_except" WS  method OWS "{" OWS *(permission-directive) OWS "}"
 
 display-dir-list-directive	= "autoindex" WS on-off OWS END_DIRECTIVE
 

--- a/docs/webserv_conf.abnf
+++ b/docs/webserv_conf.abnf
@@ -123,6 +123,7 @@ server-directive	= location-context
 					/ error-page-directive
 					/ root-directive
 					/ client-max-body-size-directive
+					/ errorlog-directive
 					/ permission-directive
 					/ autoindex-directive
 					/ index-directive

--- a/docs/webserv_conf.abnf
+++ b/docs/webserv_conf.abnf
@@ -49,11 +49,11 @@ IPv6-prefix	= 0-128
 
 ; syntax definition
 main	= [http-directive] [errorlog-directive]
-http-directive	= 1("http" OWS "{" OWS server-directive OWS "}") ;webサーバ全体の設定
+http-directive	= 1("http" OWS "{" OWS *(server-directive) OWS "}") ;webサーバ全体の設定
 errorlog-directive	= "error_log" WS file [WS level] OWS END_DIRECTIVE ;Default: logs/error.log error
 level	= "debug" / "info" / "notice" / "warn" / "error" / "crit" / "alert" / "emerg" ;指定したlevel以上を出力する
 
-server-directive	= "server" OWS "{" OWS [serverconfig] OWS "}" ;{}の中が空も許容する
+server-directive	= "server" OWS "{" OWS *(serverconfig) OWS "}" ;{}の中が空も許容する
 serverconfig	= [listen-directive] [server-name-directive] [location-directive]
 
 listen-directive	= "listen" WS address-port OWS END_DIRECTIVE

--- a/docs/webserv_conf.abnf
+++ b/docs/webserv_conf.abnf
@@ -2,7 +2,7 @@
 ALPHA	= "A" / "B" / "C" / "D" / "E" / "F" / "G" / "H" / "I" / "J" / "K" / "L" / "M" / "N" / "O" / "P" / "Q" / "R" / "S" / "T" / "U" / "V" / "W" / "X" / "Y" / "Z"
 alpha = "a" / "b" / "c" / "d" / "e" / "f" / "g" / "h" / "i" / "j" / "k" / "l" / "m" / "n" / "o" / "p" / "q" / "r" / "s" / "t" / "u" / "v" / "w" / "x" / "y" / "z"
 VCHAR	= %x21-7E ; visible (printing) characters
-VCHAR-IN-PATH	= (VCHAR - "/") ; VCHARから"/"を除く
+PATH-CHAR = (VCHAR - "/") ; VCHARから"/"を除く
 DIGIT	= "0" / "1" / "2" / "3" / "4" / "5" / "6" / "7" / "8" / "9"
 hexdig = DIGIT / "A" / "B" / "C" / "D" / "E" / "F" / "a" / "b" / "c" / "d" / "e" / "f"
 WS	= " " / "\t" / NEWLINE ;スペース、水平タブまたは改行
@@ -14,7 +14,7 @@ status	= 3(DIGIT)
 END_DIRECTIVE	= ";"
 
 absolute-path	= "/" *(path-segment)
-path-segment	= 1*( VCHAR-IN-PATH ) ["/"]
+path-segment	= 1*( PATH-CHAR ) ["/"]
 uri	= absolute-path ;表記は同じだが、uriはrootの後に追加される root/uri
 path	= absolute-path / uri 
 file	= uri
@@ -102,6 +102,7 @@ server-directive	= location-context
 					/ permission-directive
 					/ display-dir-list-directive
 					/ index-file-directive
+					/ return-directive
 
 listen-directive	= "listen" *1(WS) address-port OWS END_DIRECTIVE
 address-port	= address [ ":" port ] / port ;デフォルトaddress:0.0.0.0 デフォルトport:80

--- a/docs/webserv_conf.abnf
+++ b/docs/webserv_conf.abnf
@@ -55,12 +55,14 @@ comment	= "#" *(VCHAR) NEWLINE ; NEWLINEまでコメントアウト
 
 errorlog-directive	= "error_log" *1(WS) file OWS END_DIRECTIVE ;Default: logs/error.log error
 level	= "warn" / "error" / "emerg" ;指定したlevel以上を出力する
+
 send-timeout-directive	= "send_timeout" *1(WS) time END_DIRECTIVE;Default: 60s
 keepalive-time-directive	= "keepalive_time" *1(WS) time END_DIRECTIVE
 root-directive	= "root" *1(WS) absolute-path OWS END_DIRECTIVE
 keepalive-timeout-directive	= "keepalive_timeout" *1(WS) time OWS END_DIRECTIVE;Default: 75s
-display-dir-list-directive	= "autoindex" *1(WS) on-off OWS END_DIRECTIVE
+autoindex-directive	= "autoindex" *1(WS) on-off OWS END_DIRECTIVE
 client-max-body-size-directive	= "client_max_body_size" *1(WS) size OWS END_DIRECTIVE ;Default:1m, size to 0 disables checking of client 
+
 ;リクエストがディレクトリ(/)に対するもののレスポンスを設定。複数のファイルが存在する場合左から順に探す
 index-directive	= "index" *1(WS) 1*(file) OWS END_DIRECTIVE
 
@@ -91,13 +93,20 @@ http-directive	= errorlog-directive
 				/ root-directive
 				/ client-max-body-size-directive
 				/ permission-directive
-				/ display-dir-list-directive
+				/ autoindex-directive
 				/ index-directive
+				/ access-log-directive
+				/ userid-directive
+				/ userid-domain-directive
+				/ userid-expires-directive
+				/ userid-path-directive
+				/ userid-service-directive
 
 events-context	= 1("events" OWS "{" OWS *(events-directive) OWS "}")
 events-directive	= *1(worker-connections-directive)
 					/ *1(use-directive)
 worker-connections-directive	= "worker_connections" *1(WS) 1*(DIGIT) END_DIRECTIVE
+
 use-directive	= "use" *1(WS) connection-method OWS END_DIRECTIVE
 connection-method	= "select" / "poll" / "kqueue" / "epoll" 
 
@@ -115,9 +124,16 @@ server-directive	= location-context
 					/ root-directive
 					/ client-max-body-size-directive
 					/ permission-directive
-					/ display-dir-list-directive
+					/ autoindex-directive
 					/ index-directive
 					/ return-directive
+					/ access-log-directive
+					/ try-files-directive
+					/ userid-directive
+					/ userid-domain-directive
+					/ userid-expires-directive
+					/ userid-path-directive
+					/ userid-service-directive
 
 listen-directive	= "listen" *1(WS) address-port OWS END_DIRECTIVE
 address-port	= address [ ":" port ] / port ;デフォルトaddress:0.0.0.0 デフォルトport:80
@@ -132,14 +148,21 @@ location-directive	= root-directive
 				/ return-directive
 				/ limit-except-context
 				/ permission-directive
-				/ display-dir-list-directive
+				/ autoindex-directive
 				/ index-directive
 				/ client-max-body-size-directive
 				/ errorlog-directive
 				/ send-timeout-directive
 				/ keepalive-time-directive
 				/ keepalive-timeout-directive
-
+				/ access-log-directive
+				/ alias-directive
+				/ try-files-directive
+				/ userid-directive
+				/ userid-domain-directive
+				/ userid-expires-directive
+				/ userid-path-directive
+				/ userid-service-directive
 
 return-directive	= "return" *1(WS) status *1(WS) uri OWS END_DIRECTIVE ; redirectで使用
 alias-directive	= "alias" *1(WS) absolute-path OWS END_DIRECTIVE

--- a/docs/webserv_conf.abnf
+++ b/docs/webserv_conf.abnf
@@ -19,7 +19,7 @@ address-port	= address [ ":" port ] / port ;デフォルトaddress:0.0.0.0 デ�
 address	=  * / localhost / IPv4-address / IPv6-address 
 IPv4-address = dec-octet "." dec-octet "." dec-octet "." dec-octet
 dec-octet = DIGIT / "1"-"9" DIGIT / "1" DIGIT DIGIT / "2" "0"-"4" DIGIT / "25" "0"-"5" ; 0~255
-IPv6address	= 6( h16 ":" ) ls32
+IPv6-address	= 6( h16 ":" ) ls32
 			/ "::" 5( h16 ":" ) ls32
 			/ [               h16 ] "::" 4( h16 ":" ) ls32
 			/ [ *1( h16 ":" ) h16 ] "::" 3( h16 ":" ) ls32
@@ -34,6 +34,9 @@ h16 = 1*4(HEXDIG) ;HEXDIGが1回から4回まで続く
 port	= 1*(DIGIT)  ;少なくとも1回のDIGITが続くシーケンス
 
 server_name	= "server_name" WS alphadigit END_DIRECTIVE
+
+location	= END_DIRECTIVE
+path	= 
 
 error-page-directive	= "error_page" WS error_codes [response] END_DIRECTIVE
 error-codes = error-code *(SP error-code) END_DIRECTIVE

--- a/docs/webserv_conf.abnf
+++ b/docs/webserv_conf.abnf
@@ -57,7 +57,6 @@ errorlog-directive	= "error_log" *1(WS) file OWS END_DIRECTIVE ;Default: logs/er
 level	= "warn" / "error" / "emerg" ;指定したlevel以上を出力する
 
 send-timeout-directive	= "send_timeout" *1(WS) time END_DIRECTIVE;Default: 60s
-keepalive-time-directive	= "keepalive_time" *1(WS) time END_DIRECTIVE
 root-directive	= "root" *1(WS) absolute-path OWS END_DIRECTIVE
 keepalive-timeout-directive	= "keepalive_timeout" *1(WS) time OWS END_DIRECTIVE;Default: 75s
 autoindex-directive	= "autoindex" *1(WS) on-off OWS END_DIRECTIVE
@@ -88,7 +87,6 @@ userid-service-directive	= "userid_service" *1(WS) 1*(DIGIT) OWS END_DIRECTIVE
 
 http-directive	= errorlog-directive
 				/ send-timeout-directive
-				/ keepalive-time-directive
 				/ keepalive-timeout-directive
 				/ root-directive
 				/ client-max-body-size-directive
@@ -118,7 +116,6 @@ server-directive	= location-context
 					/ listen-directive
 					/ server-name-directive
 					/ send-timeout-directive
-					/ keepalive-time-directive
 					/ keepalive-timeout-directive
 					/ error-page-directive
 					/ root-directive
@@ -154,7 +151,6 @@ location-directive	= root-directive
 				/ client-max-body-size-directive
 				/ errorlog-directive
 				/ send-timeout-directive
-				/ keepalive-time-directive
 				/ keepalive-timeout-directive
 				/ access-log-directive
 				/ alias-directive

--- a/docs/webserv_conf.abnf
+++ b/docs/webserv_conf.abnf
@@ -12,7 +12,7 @@ END_DIRECTIVE	= ";"
 
 main	= [http-directive] [errorlog-directive]
 http-directive	= 1("http" OWS "{" OWS server-directive OWS "}") ;webサーバ全体の設定
-errorlog-directive	= "error_log" WS path [WS level] OWS END_DIRECTIVE
+errorlog-directive	= "error_log" WS file [WS level] OWS END_DIRECTIVE
 level	= "debug" / "info" / "notice" / "warn" / "error" / "crit" / "alert" / "emerg" ;指定したlevel以上を出力する
 
 server-directive	= "server" OWS "{" OWS [serverconfig] OWS "}" ;{}の中が空も許容する
@@ -40,9 +40,9 @@ port	= 1*(DIGIT)  ;少なくとも1回のDIGITが続くシーケンス
 
 server-name-directive	= "server_name" 1*(WS alphadigit) OWS END_DIRECTIVE 
 
-location-directive	= "location" WS path "{" OWS *[location-config] OWS "}"
+location-directive	= "location" WS uri "{" OWS *[location-config] OWS "}"
 location-config	= root-directive
-				/ keepalive-timeout
+				/ keepalive-timeout-directive
 				/ error-page-directive 
 				/ return-directive
 				/ limit-except-directive
@@ -51,37 +51,40 @@ location-config	= root-directive
 				/ index-file-directive
 				/ client-max-body-size-directive
 
-root-directive	= "root" WS path END_DIRECTIVE
-send-timeout	= "send_timeout" WS time-sec ;Default: 60s
-path	= "/" 1*(path-segment)
+absolute-path	= "/" *(path-segment)
 path-segment	= 1*(ALPHA / DIGIT / "-" / "_") ["/"]
-keepalive-timeout	= "keepalive_timeout" time-sec ;Default: 75s
-time-sec	= DIGIT ["s"]
+uri	= absolute-path ;表記は同じだが、uriはrootの後に追加される root/uri
+path	= absolute-path / uri 
+file	= path alphadigit
 
-return-directive	= "return" WS status WS uri OWS END_DIRECTIVE
-uri	= scheme "://" host
+time-sec	= DIGIT ["s"]
+url	= scheme "://" host
 scheme	= "http" / "https";
 host	= alphadigit
 
-client-max-body-size-directive	= "client_max_body_size" WS size-mb END_DIRECTIVE ;Default:1m, size to 0 disables checking of client request body size-mb	= DIGIT ["m"] ; megabytes
-
-error-page-directive	= "error_page" WS error_codes [response] END_DIRECTIVE
-error-codes = error-code *(SP error-code)
-error_code	= status
-response	= path-to-file
-path-to-file	= path alphadigit
-file	= alphadigit / path-to-file
-
-permission-directive	= permission WS permission-target END_DIRECTIVE
-permission-target	= ip-address / all 
-permission	= "allow" / "deny"
 ip-address	= ip-address "/" "0"-"32"
-
-limit-except-directive	= "limit_except" WS  method OWS "{" OWS *(permission-directive) OWS "}"
+on-off	= "ON" / "OFF"
 method	= "GET" / "HEAD" / "PUT" / "DELETE" ;Allowing the GET method makes the HEAD method also allowed
 
-display-dir-list-directive	= "autoindex" WS on-off PWS END_DIRECTIVE
-on-off	= "ON" / "OFF"
+root-directive	= "root" WS path OWS END_DIRECTIVE
+send-timeout	= "send_timeout" WS time-sec ;Default: 60s
+keepalive-timeout-directive	= "keepalive_timeout" time-sec OWS END_DIRECTIVE;Default: 75s
+
+return-directive	= "return" WS status WS url OWS END_DIRECTIVE
+
+client-max-body-size-directive	= "client_max_body_size" WS size-mb OWS END_DIRECTIVE ;Default:1m, size to 0 disables checking of client size-mb	= DIGIT ["m"] ; megabytes
+
+error-page-directive	= "error_page" WS error_codes ["=" status] WS uri OWS END_DIRECTIVE
+error-codes = error-code *(SP error-code)
+error_code	= status
+
+permission-directive	= permission WS permission-target OWS END_DIRECTIVE
+permission-target	= ip-address / all 
+permission	= "allow" / "deny"
+
+limit-except-directive	= "limit_except" WS  method OWS "{" OWS *(permission-directive) OWS "}"
+
+display-dir-list-directive	= "autoindex" WS on-off OWS END_DIRECTIVE
 
 index-file-directive	= "index" WS 1*(file) OWS END_DIRECTIVE;リクエストがディレクトリ(/)に対するもののレスポンスを設定。複数のファイルが存在する場合左から順に探す
 

--- a/docs/webserv_conf.abnf
+++ b/docs/webserv_conf.abnf
@@ -50,46 +50,19 @@ IPv6-prefix	= 0-128
 
 ; syntax definition
 main-context	= events-directive [ *(WS) http-context *(OWS)] [*(WS) errorlog-directive *(OWS)]
-http-context	= 1("http" OWS "{" OWS *(server-context) OWS "}") ;webサーバ全体の設定
+http-context	= 1("http" OWS "{" OWS *(server-context) *(http-directive) OWS "}") ;webサーバ全体の設定
+comment	= "#" *(VCHAR) NEWLINE ; NEWLINEまでコメントアウト
+
 errorlog-directive	= "error_log" WS file OWS END_DIRECTIVE ;Default: logs/error.log error
 level	= "warn" / "error" / "emerg" ;指定したlevel以上を出力する
-
-events-context	= 1("events" OWS "{" OWS *(events-directive) OWS "}")
-events-directive	= *1(worker-connections-directive)
-					/ *1(use-directive)
-worker-connections-directive	= "worker_connections" WS 1*(DIGIT) END_DIRECTIVE
-use-directive	= "use" WS connection-method OWS END_DIRECTIVE
-connection-method	= "select" / "poll" / "kqueue" / "epoll" 
-
-server-context	= "server" OWS "{" OWS *(server-directive) OWS "}" ;{}の中が空も許容する
-server-directive	= [listen-directive] [server-name-directive] [location-context]
-
-listen-directive	= "listen" WS address-port OWS END_DIRECTIVE
-address-port	= address [ ":" port ] / port ;デフォルトaddress:0.0.0.0 デフォルトport:80
-address	=  "*" / "localhost" / ip-address
-port	= 1*(DIGIT)  ;少なくとも1回のDIGITが続くシーケンス
-
-server-name-directive	= "server_name" 1*(WS VCHAR) OWS END_DIRECTIVE ; The first name becomes the primary server name
-
-location-context	= "location" WS uri "{" OWS *[location-directive] OWS "}"
-location-directive	= root-directive
-				/ keepalive-timeout-directive
-				/ error-page-directive 
-				/ return-directive
-				/ limit-except-context
-				/ permission-directive
-				/ display-dir-list-directive
-				/ index-file-directive
-				/ client-max-body-size-directive
-
-
+send-timeout-directive	= "send_timeout" WS time END_DIRECTIVE;Default: 60s
+keepalive-time-directive	= "keepalive_time" ws time END_DIRECTIVE
 root-directive	= "root" WS absolute-path OWS END_DIRECTIVE
-send-timeout	= "send_timeout" WS time ;Default: 60s
 keepalive-timeout-directive	= "keepalive_timeout" time OWS END_DIRECTIVE;Default: 75s
-
-return-directive	= "return" WS status WS uri OWS END_DIRECTIVE ; redirectで使用
-
+display-dir-list-directive	= "autoindex" WS on-off OWS END_DIRECTIVE
 client-max-body-size-directive	= "client_max_body_size" WS size OWS END_DIRECTIVE ;Default:1m, size to 0 disables checking of client 
+;リクエストがディレクトリ(/)に対するもののレスポンスを設定。複数のファイルが存在する場合左から順に探す
+index-file-directive	= "index" WS 1*(file) OWS END_DIRECTIVE
 
 error-page-directive	= "error_page" WS error-codes ["=" status] WS uri OWS END_DIRECTIVE
 error-codes = error-code *(SP error-code)
@@ -99,10 +72,60 @@ permission-directive	= permission WS permission-target OWS END_DIRECTIVE
 permission-target	= IPv4-address "/" IPv4-subnetmask / IPv6-address "/" IPv6-prefix / all 
 permission	= "allow" / "deny"
 
+http-directive	= errorlog-directive
+				/ send-timeout-directive
+				/ keepalive-time-directive
+				/ keepalive-timeout-directive
+				/ root-directive
+				/ client-max-body-size-directive
+				/ permission-directive
+				/ display-dir-list-directive
+				/ index-file-directive
+
+events-context	= 1("events" OWS "{" OWS *(events-directive) OWS "}")
+events-directive	= *1(worker-connections-directive)
+					/ *1(use-directive)
+worker-connections-directive	= "worker_connections" WS 1*(DIGIT) END_DIRECTIVE
+use-directive	= "use" WS connection-method OWS END_DIRECTIVE
+connection-method	= "select" / "poll" / "kqueue" / "epoll" 
+
+server-context	= "server" OWS "{" OWS *(server-directive) OWS "}" ;{}の中が空も許容する
+server-directive	= location-context
+					/ listen-directive
+					/ server-name-directive
+					/ send-timeout-directive
+					/ keepalive-time-directive
+					/ keepalive-timeout-directive
+					/ error-page-directive
+					/ root-directive
+					/ client-max-body-size-directive
+					/ permission-directive
+					/ display-dir-list-directive
+					/ index-file-directive
+					/ return-directive
+
+listen-directive	= "listen" WS address-port OWS END_DIRECTIVE
+address-port	= address [ ":" port ] / port ;デフォルトaddress:0.0.0.0 デフォルトport:80
+address	=  "*" / "localhost" / ip-address
+port	= 1*(DIGIT)  ;少なくとも1回のDIGITが続くシーケンス
+
+server-name-directive	= "server_name" 1*(WS VCHAR) OWS END_DIRECTIVE ; The first name becomes the primary server name
+
+location-context	= "location" WS uri "{" OWS *(location-directive) OWS "}"
+location-directive	= root-directive
+				/ error-page-directive 
+				/ return-directive
+				/ limit-except-context
+				/ permission-directive
+				/ display-dir-list-directive
+				/ index-file-directive
+				/ client-max-body-size-directive
+				/ errorlog-directive
+				/ send-timeout-directive
+				/ keepalive-time-directive
+				/ keepalive-timeout-directive
+
+
+return-directive	= "return" WS status WS uri OWS END_DIRECTIVE ; redirectで使用
+
 limit-except-context	= "limit_except" WS  method OWS "{" OWS *(permission-directive) OWS "}"
-
-display-dir-list-directive	= "autoindex" WS on-off OWS END_DIRECTIVE
-
-index-file-directive	= "index" WS 1*(file) OWS END_DIRECTIVE;リクエストがディレクトリ(/)に対するもののレスポンスを設定。複数のファイルが存在する場合左から順に探す
-
-comment	= "#" NEWLINE ; NEWLINEまでコメントアウト

--- a/docs/webserv_conf.abnf
+++ b/docs/webserv_conf.abnf
@@ -54,9 +54,12 @@ http-context	= 1("http" OWS "{" OWS *(server-context) OWS "}") ;webサーバ全�
 errorlog-directive	= "error_log" WS file OWS END_DIRECTIVE ;Default: logs/error.log error
 level	= "warn" / "error" / "emerg" ;指定したlevel以上を出力する
 
-events-context	= 1("events" OWS "{" OWS events-directive OWS "}")
-events-directive	= *1[worker-connections-directive]
+events-context	= 1("events" OWS "{" OWS *(events-directive) OWS "}")
+events-directive	= *1(worker-connections-directive)
+					/ *1(use-directive)
 worker-connections-directive	= "worker_connections" WS 1*(DIGIT) END_DIRECTIVE
+use-directive	= "use" WS connection-method OWS END_DIRECTIVE
+connection-method	= "select" / "poll" / "kqueue" / "epoll" 
 
 server-context	= "server" OWS "{" OWS *(server-directive) OWS "}" ;{}の中が空も許容する
 server-directive	= [listen-directive] [server-name-directive] [location-context]

--- a/docs/webserv_conf.abnf
+++ b/docs/webserv_conf.abnf
@@ -83,9 +83,9 @@ return-directive	= "return" WS status WS uri OWS END_DIRECTIVE ; redirectで使�
 
 client-max-body-size-directive	= "client_max_body_size" WS size-mb OWS END_DIRECTIVE ;Default:1m, size to 0 disables checking of client size-mb	= DIGIT ["m"] ; megabytes
 
-error-page-directive	= "error_page" WS error_codes ["=" status] WS uri OWS END_DIRECTIVE
+error-page-directive	= "error_page" WS error-codes ["=" status] WS uri OWS END_DIRECTIVE
 error-codes = error-code *(SP error-code)
-error_code	= status
+error-code	= status
 
 permission-directive	= permission WS permission-target OWS END_DIRECTIVE
 permission-target	= IPv4-address "/" IPv4-subnetmask / IPv6-address "/" IPv6-prefix / all 
@@ -97,4 +97,4 @@ display-dir-list-directive	= "autoindex" WS on-off OWS END_DIRECTIVE
 
 index-file-directive	= "index" WS 1*(file) OWS END_DIRECTIVE;リクエストがディレクトリ(/)に対するもののレスポンスを設定。複数のファイルが存在する場合左から順に探す
 
-client_max_body_size_directive	= "client_body_buffer_size" OWS DIGIT OWS END_DIRECTIVE
+comment	= "#" NEWLINE ; NEWLINEまでコメントアウト

--- a/docs/webserv_conf.abnf
+++ b/docs/webserv_conf.abnf
@@ -51,8 +51,8 @@ IPv6-prefix	= 0-128
 ; syntax definition
 main-context	= events-directive [ *(WS) http-context *(OWS)] [*(WS) errorlog-directive *(OWS)]
 http-context	= 1("http" OWS "{" OWS *(server-context) OWS "}") ;webサーバ全体の設定
-errorlog-directive	= "error_log" WS file [WS level] OWS END_DIRECTIVE ;Default: logs/error.log error
-level	= "debug" / "info" / "notice" / "warn" / "error" / "crit" / "alert" / "emerg" ;指定したlevel以上を出力する
+errorlog-directive	= "error_log" WS file OWS END_DIRECTIVE ;Default: logs/error.log error
+level	= "warn" / "error" / "emerg" ;指定したlevel以上を出力する
 
 events-context	= 1("events" OWS "{" OWS events-directive OWS "}")
 events-directive	= *1[worker-connections-directive]

--- a/docs/webserv_conf.abnf
+++ b/docs/webserv_conf.abnf
@@ -20,7 +20,8 @@ serverconfig	= [listen-directive] [server-name] [location-directive]
 
 listen-directive	= "listen" WS address-port
 address-port	= address [ ":" port ] / port ;デフォルトaddress:0.0.0.0 デフォルトport:80
-address	=  * / localhost / IPv4-address / IPv6-address 
+address	=  * / localhost / ip-address
+ip-address = IPv4-address / IPv6-address
 IPv4-address = dec-octet "." dec-octet "." dec-octet "." dec-octet
 dec-octet = DIGIT / "1"-"9" DIGIT / "1" DIGIT DIGIT / "2" "0"-"4" DIGIT / "25" "0"-"5" ; 0~255
 IPv6-address	= 6( h16 ":" ) ls32
@@ -39,8 +40,15 @@ port	= 1*(DIGIT)  ;少なくとも1回のDIGITが続くシーケンス
 
 server-name	= "server_name" 1*(WS alphadigit) END_DIRECTIVE ; 
 
-location-directive	= "location" WS path "{" *[location-config] "}"END_DIRECTIVE
-location-config	= root-directive / keepalive-timeout / error-page-directive / return-directive
+location-directive	= "location" WS path "{" OWS *[location-config] OWS "}"END_DIRECTIVE
+location-config	= root-directive
+				/ keepalive-timeout
+				/ error-page-directive 
+				/ return-directive
+				/ limit-except-directive
+				/ permission-directive
+				/ display-dir-list
+				/ index-file
 
 root-directive	= "root" WS path END_DIRECTIVE
 send-timeout	= "send_timeout" WS time-sec ;Default: 60s
@@ -50,7 +58,8 @@ keepalive-timeout	= "keepalive_timeout" time-sec ;Default: 75s
 time-sec	= DIGIT ["s"]
 
 return-directive	= "return" WS status WS uri OWS END_DIRECTIVE
-uri	= ("http" / "https") "://" host
+uri	= scheme "://" host
+scheme	= "http" / "https";
 host	= alphadigit
 
 client-max-body-size	= "client_max_body_size" WS size-mb END_DIRECTIVE ;Default:1m, size to 0 disables checking of client request body size-mb	= DIGIT ["m"] ; megabytes
@@ -60,5 +69,19 @@ error-codes = error-code *(SP error-code) END_DIRECTIVE
 error_code	= status END_DIRECTIVE
 response	= path-to-file
 path-to-file	= path alphadigit
+file	= alphadigit / path-to-file
+
+permission-directive	= permission WS permission-target END_DIRECTIVE
+permission-target	= ip-address / all 
+permission	= "allow" / "deny"
+ip-address	= ip-address "/" "0"-"32"
+
+limit-except-directive	= "limit_except" WS  method OWS "{" OWS *(permission-directive) OWS "}"
+method	= "GET" / "HEAD" / "PUT" / "DELETE" ;Allowing the GET method makes the HEAD method also allowed
+
+display-dir-list	= "autoindex" WS on-off
+on-off	= "ON" / "OFF"
+
+index-file	= "index" WS 1*(file) ;リクエストがディレクトリ(/)に対するもののレスポンスを設定。複数のファイルが存在する場合左から順に探す
 
 client_max_body_size_directive	= "client_body_buffer_size" OWS DIGIT END_DIRECTIVE

--- a/docs/webserv_conf.abnf
+++ b/docs/webserv_conf.abnf
@@ -48,10 +48,11 @@ IPv4-subnetmask	= 0-32
 IPv6-prefix	= 0-128
 
 ; syntax definition
-main-context	= [ *(OWS) http-context *(OWS)] [*(OWS) errorlog-directive *(OWS)]
+main-context	= [ *(OWS) http-context *(OWS)] [*(OWS) errorlog-directive *(OWS)] [*(OWS) worker-connections-directive *(OWS)]
 http-context	= 1("http" OWS "{" OWS *(server-context) OWS "}") ;webサーバ全体の設定
 errorlog-directive	= "error_log" WS file [WS level] OWS END_DIRECTIVE ;Default: logs/error.log error
 level	= "debug" / "info" / "notice" / "warn" / "error" / "crit" / "alert" / "emerg" ;指定したlevel以上を出力する
+worker-connections-directive	= "worker_connections" WS 1*(DIGIT) END_DIRECTIVE
 
 server-context	= "server" OWS "{" OWS *(serverconfig) OWS "}" ;{}の中が空も許容する
 serverconfig	= [listen-directive] [server-name-directive] [location-context]

--- a/docs/webserv_conf.abnf
+++ b/docs/webserv_conf.abnf
@@ -48,10 +48,13 @@ IPv4-subnetmask	= 0-32
 IPv6-prefix	= 0-128
 
 ; syntax definition
-main-context	= [ *(OWS) http-context *(OWS)] [*(OWS) errorlog-directive *(OWS)] [*(OWS) worker-connections-directive *(OWS)]
+main-context	= events-directive [ *(WS) http-context *(OWS)] [*(WS) errorlog-directive *(OWS)]
 http-context	= 1("http" OWS "{" OWS *(server-context) OWS "}") ;webサーバ全体の設定
 errorlog-directive	= "error_log" WS file [WS level] OWS END_DIRECTIVE ;Default: logs/error.log error
 level	= "debug" / "info" / "notice" / "warn" / "error" / "crit" / "alert" / "emerg" ;指定したlevel以上を出力する
+
+events-context	= 1("events" OWS "{" OWS events-directive OWS "}")
+events-directive	= *1[worker-connections-directive]
 worker-connections-directive	= "worker_connections" WS 1*(DIGIT) END_DIRECTIVE
 
 server-context	= "server" OWS "{" OWS *(server-directive) OWS "}" ;{}の中が空も許容する

--- a/docs/webserv_conf.abnf
+++ b/docs/webserv_conf.abnf
@@ -48,12 +48,12 @@ IPv4-subnetmask	= 0-32
 IPv6-prefix	= 0-128
 
 ; syntax definition
-main	= [http-directive] [errorlog-directive]
-http-directive	= 1("http" OWS "{" OWS *(server-directive) OWS "}") ;webサーバ全体の設定
+main-context	= [ *(OWS) http-context *(OWS)] [*(OWS) errorlog-directive *(OWS)]
+http-context	= 1("http" OWS "{" OWS *(server-context) OWS "}") ;webサーバ全体の設定
 errorlog-directive	= "error_log" WS file [WS level] OWS END_DIRECTIVE ;Default: logs/error.log error
 level	= "debug" / "info" / "notice" / "warn" / "error" / "crit" / "alert" / "emerg" ;指定したlevel以上を出力する
 
-server-directive	= "server" OWS "{" OWS *(serverconfig) OWS "}" ;{}の中が空も許容する
+server-context	= "server" OWS "{" OWS *(serverconfig) OWS "}" ;{}の中が空も許容する
 serverconfig	= [listen-directive] [server-name-directive] [location-directive]
 
 listen-directive	= "listen" WS address-port OWS END_DIRECTIVE

--- a/docs/webserv_conf.abnf
+++ b/docs/webserv_conf.abnf
@@ -1,0 +1,43 @@
+ALPHA	= "A" / "B" / "C" / "D" / "E" / "F" / "G" / "H" / "I" / "J" / "K" / "L" / "M" / "N" / "O" / "P" / "Q" / "R" / "S" / "T" / "U" / "V" / "W" / "X" / "Y" / "Z"
+alpha = "a" / "b" / "c" / "d" / "e" / "f" / "g" / "h" / "i" / "j" / "k" / "l" / "m" / "n" / "o" / "p" / "q" / "r" / "s" / "t" / "u" / "v" / "w" / "x" / "y" / "z"
+DIGIT	= "0" / "1" / "2" / "3" / "4" / "5" / "6" / "7" / "8" / "9"
+hexdig = DIGIT / "A" / "B" / "C" / "D" / "E" / "F" / "a" / "b" / "c" / "d" / "e" / "f"
+WS	= " " / "\t" / NEWLINE ;スペース、水平タブまたは改行
+OWS	= *(WS) optional ws
+h16 = 1*4HEXDIG
+NEWLINE	= "\n"
+alphadigit = ALPHA / alpha / DIGIT ;アルファベットまたは数字
+END_DIRECTIVE	= ";"
+
+http	= "http" OWS "{" OWS server-directive OWS "}" END_DIRECTIVE
+
+server-directive	= "server" OWS "{" serverconfig "}" END_DIRECTIVE
+serverconfig	= listen-directive END_DIRECTIVE
+
+listen-directive	= "listen" WS address-port
+address-port	= address [ ":" port ] / port ;デフォルトaddress:0.0.0.0 デフォルトport:80
+address	=  * / localhost / IPv4-address / IPv6-address 
+IPv4-address = dec-octet "." dec-octet "." dec-octet "." dec-octet
+dec-octet = DIGIT / "1"-"9" DIGIT / "1" DIGIT DIGIT / "2" "0"-"4" DIGIT / "25" "0"-"5" ; 0~255
+IPv6address	= 6( h16 ":" ) ls32
+			/ "::" 5( h16 ":" ) ls32
+			/ [               h16 ] "::" 4( h16 ":" ) ls32
+			/ [ *1( h16 ":" ) h16 ] "::" 3( h16 ":" ) ls32
+			/ [ *2( h16 ":" ) h16 ] "::" 2( h16 ":" ) ls32
+			/ [ *3( h16 ":" ) h16 ] "::"    h16 ":"   ls32
+			/ [ *4( h16 ":" ) h16 ] "::"              ls32
+			/ [ *5( h16 ":" ) h16 ] "::"              h16
+			/ [ *6( h16 ":" ) h16 ] "::"
+
+ls32	= ( h16 ":" h16 ) / IPv4address ;()はグループを示すので、右を期待する→ 16進数:16進数
+h16 = 1*4(HEXDIG) ;HEXDIGが1回から4回まで続く
+port	= 1*(DIGIT)  ;少なくとも1回のDIGITが続くシーケンス
+
+server_name	= "server_name" WS alphadigit END_DIRECTIVE
+
+error-page-directive	= "error_page" WS error_codes [response] END_DIRECTIVE
+error-codes = error-code *(SP error-code) END_DIRECTIVE
+error_code	= 3(DIGIT) END_DIRECTIVE
+response	= "/"  / URL
+
+client_max_body_size_directive	= "client_body_buffer_size" OWS DIGIT END_DIRECTIVE

--- a/docs/webserv_conf.abnf
+++ b/docs/webserv_conf.abnf
@@ -19,7 +19,7 @@ uri	= absolute-path ;表記は同じだが、uriはrootの後に追加される 
 path	= absolute-path / uri 
 file	= uri
 
-time	= 1*(DIGIT) ["ms" / "s" / "m" / "h"]
+time	= 1*(DIGIT) ["ms" / "s" / "m" / "h" / "d"]
 size	= 1*(DIGIT) ["k" / "K" / "m" / "M"]
 url	= scheme "://" host
 scheme	= "http";
@@ -62,7 +62,7 @@ keepalive-timeout-directive	= "keepalive_timeout" *1(WS) time OWS END_DIRECTIVE;
 display-dir-list-directive	= "autoindex" *1(WS) on-off OWS END_DIRECTIVE
 client-max-body-size-directive	= "client_max_body_size" *1(WS) size OWS END_DIRECTIVE ;Default:1m, size to 0 disables checking of client 
 ;リクエストがディレクトリ(/)に対するもののレスポンスを設定。複数のファイルが存在する場合左から順に探す
-index-file-directive	= "index" *1(WS) 1*(file) OWS END_DIRECTIVE
+index-directive	= "index" *1(WS) 1*(file) OWS END_DIRECTIVE
 
 error-page-directive	= "error_page" *1(WS) error-codes ["=" status] WS uri OWS END_DIRECTIVE
 error-codes = error-code *(SP error-code)
@@ -72,6 +72,18 @@ permission-directive	= permission *1(WS) permission-target OWS END_DIRECTIVE
 permission-target	= IPv4-address "/" IPv4-subnetmask / IPv6-address "/" IPv6-prefix / all 
 permission	= "allow" / "deny"
 
+access-log-directive	= "access_log" *1(WS) access-log-value OWS END_DIRECTIVE
+access-log-value = absolute-path / "off"
+
+userid-directive	= on-off OWS END_DIRECTIVE
+userid-domain-directive	= "userid_domain" *1(WS) *1(alphadigit) OWS END_DIRECTIVE
+
+userid-expires-directive	= "userid_expires" *1(WS) OWS userid-expires-value END_DIRECTIVE
+userid-expires-value	= time / "off"
+
+userid-path-directive	= "userid_path" *1(WS) absolute-path OWS END_DIRECTIVE
+userid-service-directive	= "userid_service" *1(WS) 1*(DIGIT) OWS END_DIRECTIVE
+
 http-directive	= errorlog-directive
 				/ send-timeout-directive
 				/ keepalive-time-directive
@@ -80,7 +92,7 @@ http-directive	= errorlog-directive
 				/ client-max-body-size-directive
 				/ permission-directive
 				/ display-dir-list-directive
-				/ index-file-directive
+				/ index-directive
 
 events-context	= 1("events" OWS "{" OWS *(events-directive) OWS "}")
 events-directive	= *1(worker-connections-directive)
@@ -88,6 +100,9 @@ events-directive	= *1(worker-connections-directive)
 worker-connections-directive	= "worker_connections" *1(WS) 1*(DIGIT) END_DIRECTIVE
 use-directive	= "use" *1(WS) connection-method OWS END_DIRECTIVE
 connection-method	= "select" / "poll" / "kqueue" / "epoll" 
+
+try-files-directive	= "try_files" *1(WS) try-files-value OWS END_DIRECTIVE
+try-files-value	= *2(uri 1*(WS)) ["=" status] OWS END_DIRECTIVE
 
 server-context	= "server" OWS "{" OWS *(server-directive) OWS "}" ;{}の中が空も許容する
 server-directive	= location-context
@@ -101,7 +116,7 @@ server-directive	= location-context
 					/ client-max-body-size-directive
 					/ permission-directive
 					/ display-dir-list-directive
-					/ index-file-directive
+					/ index-directive
 					/ return-directive
 
 listen-directive	= "listen" *1(WS) address-port OWS END_DIRECTIVE
@@ -118,7 +133,7 @@ location-directive	= root-directive
 				/ limit-except-context
 				/ permission-directive
 				/ display-dir-list-directive
-				/ index-file-directive
+				/ index-directive
 				/ client-max-body-size-directive
 				/ errorlog-directive
 				/ send-timeout-directive
@@ -127,5 +142,6 @@ location-directive	= root-directive
 
 
 return-directive	= "return" *1(WS) status *1(WS) uri OWS END_DIRECTIVE ; redirectで使用
+alias-directive	= "alias" *1(WS) absolute-path OWS END_DIRECTIVE
 
 limit-except-context	= "limit_except" *1(WS)  method OWS "{" OWS *(permission-directive) OWS "}"

--- a/docs/webserv_conf.abnf
+++ b/docs/webserv_conf.abnf
@@ -54,8 +54,8 @@ errorlog-directive	= "error_log" WS file [WS level] OWS END_DIRECTIVE ;Default: 
 level	= "debug" / "info" / "notice" / "warn" / "error" / "crit" / "alert" / "emerg" ;指定したlevel以上を出力する
 worker-connections-directive	= "worker_connections" WS 1*(DIGIT) END_DIRECTIVE
 
-server-context	= "server" OWS "{" OWS *(serverconfig) OWS "}" ;{}の中が空も許容する
-serverconfig	= [listen-directive] [server-name-directive] [location-context]
+server-context	= "server" OWS "{" OWS *(server-directive) OWS "}" ;{}の中が空も許容する
+server-directive	= [listen-directive] [server-name-directive] [location-context]
 
 listen-directive	= "listen" WS address-port OWS END_DIRECTIVE
 address-port	= address [ ":" port ] / port ;デフォルトaddress:0.0.0.0 デフォルトport:80
@@ -64,8 +64,8 @@ port	= 1*(DIGIT)  ;少なくとも1回のDIGITが続くシーケンス
 
 server-name-directive	= "server_name" 1*(WS VCHAR) OWS END_DIRECTIVE ; The first name becomes the primary server name
 
-location-context	= "location" WS uri "{" OWS *[location-config] OWS "}"
-location-config	= root-directive
+location-context	= "location" WS uri "{" OWS *[location-directive] OWS "}"
+location-directive	= root-directive
 				/ keepalive-timeout-directive
 				/ error-page-directive 
 				/ return-directive

--- a/docs/webserv_conf.abnf
+++ b/docs/webserv_conf.abnf
@@ -102,7 +102,6 @@ server-directive	= location-context
 					/ permission-directive
 					/ display-dir-list-directive
 					/ index-file-directive
-					/ return-directive
 
 listen-directive	= "listen" *1(WS) address-port OWS END_DIRECTIVE
 address-port	= address [ ":" port ] / port ;デフォルトaddress:0.0.0.0 デフォルトport:80

--- a/docs/webserv_conf.abnf
+++ b/docs/webserv_conf.abnf
@@ -22,7 +22,7 @@ file	= uri
 time	= 1*(DIGIT) ["ms" / "s" / "m" / "h"]
 size	= 1*(DIGIT) ["k" / "K" / "m" / "M"]
 url	= scheme "://" host
-scheme	= "http" / "https";
+scheme	= "http";
 host	= VCHAR
 
 ip-address	= ip-address "/" "0"-"32"

--- a/docs/webserv_conf.abnf
+++ b/docs/webserv_conf.abnf
@@ -53,22 +53,22 @@ main-context	= events-directive [ *(WS) http-context *(OWS)] [*(WS) errorlog-dir
 http-context	= 1("http" OWS "{" OWS *(server-context) *(http-directive) OWS "}") ;webサーバ全体の設定
 comment	= "#" *(VCHAR) NEWLINE ; NEWLINEまでコメントアウト
 
-errorlog-directive	= "error_log" WS file OWS END_DIRECTIVE ;Default: logs/error.log error
+errorlog-directive	= "error_log" *1(WS) file OWS END_DIRECTIVE ;Default: logs/error.log error
 level	= "warn" / "error" / "emerg" ;指定したlevel以上を出力する
-send-timeout-directive	= "send_timeout" WS time END_DIRECTIVE;Default: 60s
-keepalive-time-directive	= "keepalive_time" ws time END_DIRECTIVE
-root-directive	= "root" WS absolute-path OWS END_DIRECTIVE
-keepalive-timeout-directive	= "keepalive_timeout" time OWS END_DIRECTIVE;Default: 75s
-display-dir-list-directive	= "autoindex" WS on-off OWS END_DIRECTIVE
-client-max-body-size-directive	= "client_max_body_size" WS size OWS END_DIRECTIVE ;Default:1m, size to 0 disables checking of client 
+send-timeout-directive	= "send_timeout" *1(WS) time END_DIRECTIVE;Default: 60s
+keepalive-time-directive	= "keepalive_time" *1(WS) time END_DIRECTIVE
+root-directive	= "root" *1(WS) absolute-path OWS END_DIRECTIVE
+keepalive-timeout-directive	= "keepalive_timeout" *1(WS) time OWS END_DIRECTIVE;Default: 75s
+display-dir-list-directive	= "autoindex" *1(WS) on-off OWS END_DIRECTIVE
+client-max-body-size-directive	= "client_max_body_size" *1(WS) size OWS END_DIRECTIVE ;Default:1m, size to 0 disables checking of client 
 ;リクエストがディレクトリ(/)に対するもののレスポンスを設定。複数のファイルが存在する場合左から順に探す
-index-file-directive	= "index" WS 1*(file) OWS END_DIRECTIVE
+index-file-directive	= "index" *1(WS) 1*(file) OWS END_DIRECTIVE
 
-error-page-directive	= "error_page" WS error-codes ["=" status] WS uri OWS END_DIRECTIVE
+error-page-directive	= "error_page" *1(WS) error-codes ["=" status] WS uri OWS END_DIRECTIVE
 error-codes = error-code *(SP error-code)
 error-code	= status
 
-permission-directive	= permission WS permission-target OWS END_DIRECTIVE
+permission-directive	= permission *1(WS) permission-target OWS END_DIRECTIVE
 permission-target	= IPv4-address "/" IPv4-subnetmask / IPv6-address "/" IPv6-prefix / all 
 permission	= "allow" / "deny"
 
@@ -85,8 +85,8 @@ http-directive	= errorlog-directive
 events-context	= 1("events" OWS "{" OWS *(events-directive) OWS "}")
 events-directive	= *1(worker-connections-directive)
 					/ *1(use-directive)
-worker-connections-directive	= "worker_connections" WS 1*(DIGIT) END_DIRECTIVE
-use-directive	= "use" WS connection-method OWS END_DIRECTIVE
+worker-connections-directive	= "worker_connections" *1(WS) 1*(DIGIT) END_DIRECTIVE
+use-directive	= "use" *1(WS) connection-method OWS END_DIRECTIVE
 connection-method	= "select" / "poll" / "kqueue" / "epoll" 
 
 server-context	= "server" OWS "{" OWS *(server-directive) OWS "}" ;{}の中が空も許容する
@@ -104,14 +104,14 @@ server-directive	= location-context
 					/ index-file-directive
 					/ return-directive
 
-listen-directive	= "listen" WS address-port OWS END_DIRECTIVE
+listen-directive	= "listen" *1(WS) address-port OWS END_DIRECTIVE
 address-port	= address [ ":" port ] / port ;デフォルトaddress:0.0.0.0 デフォルトport:80
 address	=  "*" / "localhost" / ip-address
 port	= 1*(DIGIT)  ;少なくとも1回のDIGITが続くシーケンス
 
 server-name-directive	= "server_name" 1*(WS VCHAR) OWS END_DIRECTIVE ; The first name becomes the primary server name
 
-location-context	= "location" WS uri "{" OWS *(location-directive) OWS "}"
+location-context	= "location" *1(WS) uri "{" OWS *(location-directive) OWS "}"
 location-directive	= root-directive
 				/ error-page-directive 
 				/ return-directive
@@ -126,6 +126,6 @@ location-directive	= root-directive
 				/ keepalive-timeout-directive
 
 
-return-directive	= "return" WS status WS uri OWS END_DIRECTIVE ; redirectで使用
+return-directive	= "return" *1(WS) status *1(WS) uri OWS END_DIRECTIVE ; redirectで使用
 
-limit-except-context	= "limit_except" WS  method OWS "{" OWS *(permission-directive) OWS "}"
+limit-except-context	= "limit_except" *1(WS)  method OWS "{" OWS *(permission-directive) OWS "}"

--- a/docs/webserv_conf.abnf
+++ b/docs/webserv_conf.abnf
@@ -19,7 +19,7 @@ uri	= absolute-path ;表記は同じだが、uriはrootの後に追加される 
 path	= absolute-path / uri 
 file	= uri
 
-time-sec	= DIGIT ["s"]
+time	= DIGIT ["ms" / "s" / "m" / "h"]
 url	= scheme "://" host
 scheme	= "http" / "https";
 host	= VCHAR
@@ -80,8 +80,8 @@ location-directive	= root-directive
 
 
 root-directive	= "root" WS absolute-path OWS END_DIRECTIVE
-send-timeout	= "send_timeout" WS time-sec ;Default: 60s
-keepalive-timeout-directive	= "keepalive_timeout" time-sec OWS END_DIRECTIVE;Default: 75s
+send-timeout	= "send_timeout" WS time ;Default: 60s
+keepalive-timeout-directive	= "keepalive_timeout" time OWS END_DIRECTIVE;Default: 75s
 
 return-directive	= "return" WS status WS uri OWS END_DIRECTIVE ; redirectで使用
 

--- a/docs/webserv_conf.abnf
+++ b/docs/webserv_conf.abnf
@@ -1,5 +1,8 @@
+; basic rules
 ALPHA	= "A" / "B" / "C" / "D" / "E" / "F" / "G" / "H" / "I" / "J" / "K" / "L" / "M" / "N" / "O" / "P" / "Q" / "R" / "S" / "T" / "U" / "V" / "W" / "X" / "Y" / "Z"
 alpha = "a" / "b" / "c" / "d" / "e" / "f" / "g" / "h" / "i" / "j" / "k" / "l" / "m" / "n" / "o" / "p" / "q" / "r" / "s" / "t" / "u" / "v" / "w" / "x" / "y" / "z"
+VCHAR	= %x21-7E ; visible (printing) characters
+VCHAR-IN-PATH	= (VCHAR - "/") ; VCHARから"/"を除く
 DIGIT	= "0" / "1" / "2" / "3" / "4" / "5" / "6" / "7" / "8" / "9"
 hexdig = DIGIT / "A" / "B" / "C" / "D" / "E" / "F" / "a" / "b" / "c" / "d" / "e" / "f"
 WS	= " " / "\t" / NEWLINE ;スペース、水平タブまたは改行
@@ -10,17 +13,22 @@ alphadigit = ALPHA / alpha / DIGIT ;アルファベットまたは数字
 status	= 3(DIGIT)
 END_DIRECTIVE	= ";"
 
-main	= [http-directive] [errorlog-directive]
-http-directive	= 1("http" OWS "{" OWS server-directive OWS "}") ;webサーバ全体の設定
-errorlog-directive	= "error_log" WS file [WS level] OWS END_DIRECTIVE
-level	= "debug" / "info" / "notice" / "warn" / "error" / "crit" / "alert" / "emerg" ;指定したlevel以上を出力する
+absolute-path	= "/" *(path-segment)
+path-segment	= 1*( VCHAR-IN-PATH ) ["/"]
+uri	= absolute-path ;表記は同じだが、uriはrootの後に追加される root/uri
+path	= absolute-path / uri 
+file	= uri
 
-server-directive	= "server" OWS "{" OWS [serverconfig] OWS "}" ;{}の中が空も許容する
-serverconfig	= [listen-directive] [server-name-directive] [location-directive]
+time-sec	= DIGIT ["s"]
+url	= scheme "://" host
+scheme	= "http" / "https";
+host	= VCHAR
 
-listen-directive	= "listen" WS address-port OWS END_DIRECTIVE
-address-port	= address [ ":" port ] / port ;デフォルトaddress:0.0.0.0 デフォルトport:80
-address	=  * / localhost / ip-address
+ip-address	= ip-address "/" "0"-"32"
+on-off	= "ON" / "OFF"
+method	= "GET" / "HEAD" / "PUT" / "DELETE" ;Allowing the GET method makes the HEAD method also allowed
+
+;ip rules
 ip-address = IPv4-address / IPv6-address
 IPv4-address = dec-octet "." dec-octet "." dec-octet "." dec-octet
 dec-octet = DIGIT / "1"-"9" DIGIT / "1" DIGIT DIGIT / "2" "0"-"4" DIGIT / "25" "0"-"5" ; 0~255
@@ -36,9 +44,24 @@ IPv6-address	= 6( h16 ":" ) ls32
 
 ls32	= ( h16 ":" h16 ) / IPv4address ;()はグループを示すので、右を期待する→ 16進数:16進数
 h16 = 1*4(HEXDIG) ;HEXDIGが1回から4回まで続く
+IPv4-subnetmask	= 0-32
+IPv6-prefix	= 0-128
+
+; syntax definition
+main	= [http-directive] [errorlog-directive]
+http-directive	= 1("http" OWS "{" OWS server-directive OWS "}") ;webサーバ全体の設定
+errorlog-directive	= "error_log" WS file [WS level] OWS END_DIRECTIVE ;Default: logs/error.log error
+level	= "debug" / "info" / "notice" / "warn" / "error" / "crit" / "alert" / "emerg" ;指定したlevel以上を出力する
+
+server-directive	= "server" OWS "{" OWS [serverconfig] OWS "}" ;{}の中が空も許容する
+serverconfig	= [listen-directive] [server-name-directive] [location-directive]
+
+listen-directive	= "listen" WS address-port OWS END_DIRECTIVE
+address-port	= address [ ":" port ] / port ;デフォルトaddress:0.0.0.0 デフォルトport:80
+address	=  "*" / "localhost" / ip-address
 port	= 1*(DIGIT)  ;少なくとも1回のDIGITが続くシーケンス
 
-server-name-directive	= "server_name" 1*(WS alphadigit) OWS END_DIRECTIVE 
+server-name-directive	= "server_name" 1*(WS VCHAR) OWS END_DIRECTIVE ; The first name becomes the primary server name
 
 location-directive	= "location" WS uri "{" OWS *[location-config] OWS "}"
 location-config	= root-directive
@@ -51,26 +74,12 @@ location-config	= root-directive
 				/ index-file-directive
 				/ client-max-body-size-directive
 
-absolute-path	= "/" *(path-segment)
-path-segment	= 1*(ALPHA / DIGIT / "-" / "_") ["/"]
-uri	= absolute-path ;表記は同じだが、uriはrootの後に追加される root/uri
-path	= absolute-path / uri 
-file	= path alphadigit
 
-time-sec	= DIGIT ["s"]
-url	= scheme "://" host
-scheme	= "http" / "https";
-host	= alphadigit
-
-ip-address	= ip-address "/" "0"-"32"
-on-off	= "ON" / "OFF"
-method	= "GET" / "HEAD" / "PUT" / "DELETE" ;Allowing the GET method makes the HEAD method also allowed
-
-root-directive	= "root" WS path OWS END_DIRECTIVE
+root-directive	= "root" WS absolute-path OWS END_DIRECTIVE
 send-timeout	= "send_timeout" WS time-sec ;Default: 60s
 keepalive-timeout-directive	= "keepalive_timeout" time-sec OWS END_DIRECTIVE;Default: 75s
 
-return-directive	= "return" WS status WS url OWS END_DIRECTIVE
+return-directive	= "return" WS status WS uri OWS END_DIRECTIVE ; redirectで使用
 
 client-max-body-size-directive	= "client_max_body_size" WS size-mb OWS END_DIRECTIVE ;Default:1m, size to 0 disables checking of client size-mb	= DIGIT ["m"] ; megabytes
 
@@ -79,7 +88,7 @@ error-codes = error-code *(SP error-code)
 error_code	= status
 
 permission-directive	= permission WS permission-target OWS END_DIRECTIVE
-permission-target	= ip-address / all 
+permission-target	= IPv4-address "/" IPv4-subnetmask / IPv6-address "/" IPv6-prefix / all 
 permission	= "allow" / "deny"
 
 limit-except-directive	= "limit_except" WS  method OWS "{" OWS *(permission-directive) OWS "}"

--- a/docs/webserv_conf.abnf
+++ b/docs/webserv_conf.abnf
@@ -7,11 +7,12 @@ OWS	= *(WS) ;optional ws
 h16 = 1*4HEXDIG
 NEWLINE	= "\n"
 alphadigit = ALPHA / alpha / DIGIT ;アルファベットまたは数字
+status	= 3(DIGIT)
 END_DIRECTIVE	= ";"
 
 main	= [http] [errorlog]
 http	= 1("http" OWS "{" OWS server-directive OWS "}") ;webサーバ全体の設定
-errorlog	= path WS level OWS END_DIRECTIVE
+errorlog	= "error_log" WS path [WS level] OWS END_DIRECTIVE
 level	= "debug" / "info" / "notice" / "warn" / "error" / "crit" / "alert" / "emerg" ;指定したlevel以上を出力する
 
 server-directive	= "server" OWS "{" [serverconfig] "}" ;{}の中が空も許容する
@@ -39,18 +40,24 @@ port	= 1*(DIGIT)  ;少なくとも1回のDIGITが続くシーケンス
 server-name	= "server_name" 1*(WS alphadigit) END_DIRECTIVE ; 
 
 location-directive	= "location" WS path "{" *[location-config] "}"END_DIRECTIVE
-location-config	= root-directive / keepalive-timeout / error-page-directive
+location-config	= root-directive / keepalive-timeout / error-page-directive / return-directive
+
 root-directive	= "root" WS path END_DIRECTIVE
 send-timeout	= "send_timeout" WS time-sec ;Default: 60s
 path	= "/" 1*(path-segment)
 path-segment	= 1*(ALPHA / DIGIT / "-" / "_") ["/"]
 keepalive-timeout	= "keepalive_timeout" time-sec ;Default: 75s
 time-sec	= DIGIT ["s"]
+
+return-directive	= "return" WS status WS uri OWS END_DIRECTIVE
+uri	= ("http" / "https") "://" host
+host	= alphadigit
+
 client-max-body-size	= "client_max_body_size" WS size-mb END_DIRECTIVE ;Default:1m, size to 0 disables checking of client request body size-mb	= DIGIT ["m"] ; megabytes
 
 error-page-directive	= "error_page" WS error_codes [response] END_DIRECTIVE
 error-codes = error-code *(SP error-code) END_DIRECTIVE
-error_code	= 3(DIGIT) END_DIRECTIVE
+error_code	= status END_DIRECTIVE
 response	= path-to-file
 path-to-file	= path alphadigit
 


### PR DESCRIPTION
お疲れ様です。
cgi以外対応しました。
以下を参考にレビューいただくと幸いです。
https://nginx.org/en/docs/http/ngx_http_core_module.html
https://github.com/JUNNETWORKS/42-webserv/blob/main/docs/configuration.g4
https://datatracker.ietf.org/doc/html/rfc5234
https://github.com/YungTatyu/webserv/wiki/%E8%A6%81%E4%BB%B6%E5%AE%9A%E7%BE%A9

### 対応済み
- http
- errorlog
- server
- listen
- server-name
- keepalive-timeout
- client-max-body-size
- error_page
- HTTPリダイレクトを定義
- ルートの受け入れるHTTPメソッドのリストを定義
- ディレクトリ一覧表示のオンまたはオフの切り替え
- リクエストがディレクトリの場合、リスポンスのデフォルトのファイルを設定
- 特定のルート（URLパス）において、クライアントがファイルをアップロードできるようにし、アップロードされたファイルがどこに保存されるかを設定できるようにする

### 未対応
- 特定のファイル拡張子に基づいてCGIを実行



