### PR TITLE
[issue88] Github Actionsで自動でビルドテスト

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,42 @@
+name: Compile Test (on PR)
+
+on:
+  pull_request:
+    types:
+      - ready_for_review
+
+jobs:
+  build-macos:
+    if: github.event.pull_request.draft == false
+    name: Build on macOS
+    runs-on: macos-latest
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Run make (macOS)
+      run: make
+
+  build-ubuntu:
+    if: github.event.pull_request.draft == false
+    name: Build on Ubuntu
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Run make (Ubuntu)
+      run: make
+
+  build-windows:
+    if: github.event.pull_request.draft == false
+    name: Build on Windows
+    runs-on: windows-latest
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Run make (Windows)
+      run: make
+
+

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,4 +1,4 @@
-name: Compile Test (on PR)
+name: Compile Test
 
 on:
   pull_request:
@@ -27,16 +27,4 @@ jobs:
 
     - name: Run make (Ubuntu)
       run: make
-
-  build-windows:
-    if: github.event.pull_request.draft == false
-    name: Build on Windows
-    runs-on: windows-latest
-
-    steps:
-    - uses: actions/checkout@v2
-
-    - name: Run make (Windows)
-      run: make
-
 


### PR DESCRIPTION
#88 

# Problem
環境によってコンパイルが通ったり通らなかったりしていちいち確認したり、後から直すのめんどくさい。

# Suggestion
Github Actionsを使ってプルリクにプッシュした時に、ビルドテストが通るようにする。

とはいえ毎回テストが走ったら面倒（まだ作成途中とか）。なので作成中はDraftにしておき、完成したらReady for Reviewに変更。その際にビルドテストが走るようにする。

# Note
mainへのpush時（つまりこのリポジトリではプルリクマージ時）にビルドテストを実行して失敗したらマージしない、みたいにしてもいいけど、レビューの時に分かった方が良さげだからready for reviewの時に実行するようにした。

今はビルドテストだけだけど、make testもworkflowに追加してもいいかも。

# Example
<img width="1470" alt="image" src="https://github.com/YungTatyu/webserv/assets/80312261/a4254e8e-ef70-470f-9e08-720c99309602">