### PR TITLE
Run build-test even when PR is active from start

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -3,6 +3,9 @@ name: Compile Test
 on:
   pull_request:
     types:
+      - opened
+      - reopened
+      - synchronize
       - ready_for_review
 
 jobs:


### PR DESCRIPTION
https://techblog.finatext.com/github-actions-how-to-disable-ci-in-draft-pull-requests-5989a228afaf