### PR TITLE
Issue129 http request-headerをcase insensitiveに対応

### DIFF
--- a/src/server/CGIExecutor.cpp
+++ b/src/server/CGIExecutor.cpp
@@ -107,8 +107,8 @@ void	cgi::CGIExecutor::createMetaVars(const HttpRequest& request)
 	const static std::string	script_name = std::string("SCRIPT_NAME=") + request.uri;
 	this->meta_vars_.push_back(script_name.c_str());
 
-	// const static std::string	server_name = std::string("SERVER_NAME=") + request.headers.at("host");
-	// this->meta_vars_.push_back(server_name.c_str());
+	const static std::string	server_name = std::string("SERVER_NAME=") + request.headers.at("host");
+	this->meta_vars_.push_back(server_name.c_str());
 
 	const static std::string	server_port = std::string("SERVER_PORT="); // TODO: clientがアクセスしたport番号
 	this->meta_vars_.push_back(server_port.c_str());

--- a/src/server/CGIExecutor.cpp
+++ b/src/server/CGIExecutor.cpp
@@ -82,7 +82,7 @@ void	cgi::CGIExecutor::createMetaVars(const HttpRequest& request, const int cli_
 
 	this->meta_vars_.push_back("AUTH_TYPE="); // Authorizationをparseするロジックを実装しないため、値は空文字
 
-	const static std::string content_length = std::string("CONTENT_LENGTH=") + toStr(request.body.size());
+	const static std::string content_length = std::string("CONTENT_LENGTH=") + Utils::toStr(request.body.size());
 	this->meta_vars_.push_back(content_length.c_str());
 
 	static std::string	content_type = "CONTENT_TYPE=";
@@ -112,7 +112,7 @@ void	cgi::CGIExecutor::createMetaVars(const HttpRequest& request, const int cli_
 	const static std::string	server_name = std::string("SERVER_NAME=") + request.headers.at("host");
 	this->meta_vars_.push_back(server_name.c_str());
 
-	const static std::string	server_port = std::string("SERVER_PORT="); // TODO: clientがアクセスしたport番号
+	const static std::string	server_port = std::string("SERVER_PORT=") + Utils::toStr(Utils::resolveConnectedPort(cli_sock)); 
 	this->meta_vars_.push_back(server_port.c_str());
 
 	const static std::string	server_protocol = std::string("SERVER_PROTOCOL=") + request.version;

--- a/src/server/CGIExecutor.cpp
+++ b/src/server/CGIExecutor.cpp
@@ -104,7 +104,7 @@ void	cgi::CGIExecutor::createMetaVars(const HttpRequest& request, const int cli_
 	static std::string	remote_host = std::string("REMOTE_HOST=") + ip_address; // client host nameは取得できないので、ip address
 	this->meta_vars_.push_back(remote_host.c_str());
 
-	const std::string	method = std::string("REQUEST_METHOD=") + config::LimitExcept::MethodToStr(request.method);
+	const static std::string	method = std::string("REQUEST_METHOD=") + config::LimitExcept::MethodToStr(request.method);
 	this->meta_vars_.push_back(method.c_str());
 
 	const static std::string	script_name = std::string("SCRIPT_NAME=") + request.uri;

--- a/src/server/CGIExecutor.cpp
+++ b/src/server/CGIExecutor.cpp
@@ -97,11 +97,12 @@ void	cgi::CGIExecutor::createMetaVars(const HttpRequest& request, const int cli_
 	const static std::string	query_string = std::string("QUERY_STRING=") + request.queries;
 	this->meta_vars_.push_back(query_string.c_str()); // pathinfoと同じ
 
-	const static std::string	remote_addr = std::string("REMOTE_ADDR=") + Utils::socketToStrIPAddress(cli_sock);
+	const std::string	ip_address = Utils::socketToStrIPAddress(cli_sock);
+	const static std::string	remote_addr = std::string("REMOTE_ADDR=") + ip_address;
 	this->meta_vars_.push_back(remote_addr.c_str());
 
-	static std::string	remote_host = std::string("REMOTE_HOST="); // client host name
-	this->meta_vars_.push_back(remote_host.c_str()); // TODO: client host nameを取得
+	static std::string	remote_host = std::string("REMOTE_HOST=") + ip_address; // client host nameは取得できないので、ip address
+	this->meta_vars_.push_back(remote_host.c_str());
 
 	const std::string	method = std::string("REQUEST_METHOD=") + config::LimitExcept::MethodToStr(request.method);
 	this->meta_vars_.push_back(method.c_str());

--- a/src/server/CGIExecutor.hpp
+++ b/src/server/CGIExecutor.hpp
@@ -20,7 +20,6 @@ class CGIExecutor
 		void	createMetaVars(const HttpRequest& request, const int cli_sock);
 		std::vector<std::string>	split(const std::string& s, char delimiter) const;
 		std::string	searchCommandInPath(const std::string& command) const;
-		template<typename T>std::string	toStr(const T value) const;
 		bool	isExecutableFile(const std::string& path) const;
 
 	public:
@@ -32,15 +31,6 @@ class CGIExecutor
 		const std::vector<const char*>&	getMetaVars() const;
 		bool	redirectStdIOToSocket(const HttpRequest& request, const int socket) const;
 };
-
-template<typename T>
-std::string	CGIExecutor::toStr(const T value) const
-{
-	std::stringstream	converter;
-	converter << value;
-	return converter.str();
-}
-
 } // namespace cgi
 
 #endif

--- a/src/server/CGIExecutor.hpp
+++ b/src/server/CGIExecutor.hpp
@@ -14,10 +14,10 @@ class CGIExecutor
 		std::string	script_path_;
 		std::vector<const char*>	argv_;
 		std::vector<const char*>	meta_vars_; // メタ変数(環境変数)
-		void	prepareCgiExecution(const HttpRequest& request, const std::string& script_path, const int socket);
+		void	prepareCgiExecution(const HttpRequest& request, const std::string& script_path, const int cgi_sock, const int cli_sock);
 		void	createScriptPath(const std::string& script_path);
 		void	createArgv(const std::string& script_path);
-		void	createMetaVars(const HttpRequest& request);
+		void	createMetaVars(const HttpRequest& request, const int cli_sock);
 		std::vector<std::string>	split(const std::string& s, char delimiter) const;
 		std::string	searchCommandInPath(const std::string& command) const;
 		template<typename T>std::string	toStr(const T value) const;
@@ -26,7 +26,7 @@ class CGIExecutor
 	public:
 		CGIExecutor();
 		~CGIExecutor();
-		void	executeCgiScript(const HttpRequest& request, const std::string& script_path, const int socket);
+		void	executeCgiScript(const HttpRequest& request, const std::string& script_path, const int cgi_sock, const int cli_sock);
 		const std::string&	getScriptPath() const;
 		const std::vector<const char*>&	getArgv() const;
 		const std::vector<const char*>&	getMetaVars() const;

--- a/src/server/CGIHandler.cpp
+++ b/src/server/CGIHandler.cpp
@@ -54,7 +54,7 @@ bool	cgi::CGIHandler::forkCgiProcess(
 	if (pid == 0)
 	{
 		close(this->sockets_[SOCKET_PARENT]);
-		this->cgi_executor_.executeCgiScript(request, script_path, this->sockets_[SOCKET_CHILD]);
+		this->cgi_executor_.executeCgiScript(request, script_path, this->sockets_[SOCKET_CHILD], this->cli_socket_);
 	}
 	this->cgi_process_id_ = pid;
 	close(this->sockets_[SOCKET_CHILD]);

--- a/src/server/CGIHandler.hpp
+++ b/src/server/CGIHandler.hpp
@@ -7,7 +7,6 @@
 
 #include "CGIParser.hpp"
 #include "CGIExecutor.hpp"
-#include "ConnectionManager.hpp"
 
 namespace cgi
 {
@@ -24,6 +23,7 @@ class CGIHandler
 	private:
 		CGIParser	cgi_parser_;
 		CGIExecutor	cgi_executor_;
+		int	cli_socket_; // cgiが紐づくクライアント
 		pid_t	cgi_process_id_;
 		bool	forkCgiProcess(
 			const HttpRequest& request,

--- a/src/server/ConnectionManager.hpp
+++ b/src/server/ConnectionManager.hpp
@@ -6,8 +6,10 @@
 
 # include "HttpRequest.hpp"
 # include "HttpResponse.hpp"
+# include "CGIHandler.hpp"
 
 struct TiedServer;
+class CGIHandler;
 
 class ConnectionData
 {
@@ -23,6 +25,7 @@ class ConnectionData
 		EVENT event;
 		HttpRequest request;
 		HttpResponse response_;
+		cgi::CGIHandler cgi_handler_;
 		const TiedServer* tied_server_;
 };
 

--- a/src/server/HttpRequest.cpp
+++ b/src/server/HttpRequest.cpp
@@ -3,7 +3,7 @@
 
 HttpRequest::HttpRequest(const config::REQUEST_METHOD& method, const std::string &uri,
 			 const std::string &version,
-			 const std::map<std::string, std::string> &headers,
+			 const std::map<std::string, std::string, Utils::CaseInsensitiveCompare> &headers,
 			 const std::string &queries, const std::string &body,
 			 const ParseState parseState)
     : method(method), uri(uri), version(version), headers(headers),

--- a/src/server/HttpRequest.hpp
+++ b/src/server/HttpRequest.hpp
@@ -2,6 +2,7 @@
 #define HTTPREQUEST_HPP
 
 #include "LimitExcept.hpp"
+#include "Utils.hpp"
 #include <cctype>
 #include <cstdlib>
 #include <iostream>
@@ -29,8 +30,8 @@ class HttpRequest
 	HttpRequest(const config::REQUEST_METHOD &method = config::UNKNOWN,
 		    const std::string &uri = "",
 		    const std::string &version = "",
-		    const std::map<std::string, std::string> &headers =
-			std::map<std::string, std::string>(),
+		    const std::map<std::string, std::string, Utils::CaseInsensitiveCompare> &headers =
+			std::map<std::string, std::string, Utils::CaseInsensitiveCompare>(),
 		    const std::string &queries = "",
 		    const std::string &body = "",
 		    const ParseState parseState = PARSE_BEFORE);
@@ -47,9 +48,7 @@ class HttpRequest
 	config::REQUEST_METHOD method;
 	std::string uri; // スキーマ、ポートは？？
 	std::string version;
-	std::map<std::string, std::string>
-	    headers; // hashにするためには、unordered_mapを使った方がいい。mapは赤黒木なので計算量logN.hashは最悪O(N)だけど基本O(1).
-		     // -> が、C++11では使えなかった。
+	std::map<std::string, std::string, Utils::CaseInsensitiveCompare>	headers;
 	std::string
 	    queries; // mapでもっていたが、子プロセスにQUERY_STRINGとして渡すからstringの方が良さげ。
 	std::string body;

--- a/src/utils/Utils.cpp
+++ b/src/utils/Utils.cpp
@@ -6,7 +6,6 @@
 #include <stdlib.h>
 #include <sys/param.h>
 #include <sys/socket.h>
-#include <netinet/in.h>
 
 int	Utils::wrapperOpen( const std::string path, int flags, mode_t modes )
 {
@@ -131,6 +130,31 @@ ssize_t	Utils::wrapperWrite( const int fd, const std::string& msg )
 	return written_bytes;
 }
 
+bool	Utils::wrapperGetsockname(struct sockaddr_in& addr, const int sock)
+{
+	socklen_t	client_addrlen = sizeof(addr);
+	if (getsockname(sock, reinterpret_cast<struct sockaddr*>(&addr), &client_addrlen) == -1)
+	{
+		std::cerr << "webserv: [emerge] getsockname() \"" << sock << "\" failed (" << errno << ": " << strerror(errno) << ")" << std::endl;
+		return false;
+	}
+	return true;
+}
+
+/**
+ * @brief clientがリクエストを送ったサーバーのport番号を返す
+ * 
+ * @param sock 
+ * @return int 
+ */
+int	Utils::resolveConnectedPort(const int sock)
+{
+	struct sockaddr_in addr;
+	if (!wrapperGetsockname(addr, sock))
+		return -1;
+	return ntohs(addr.sin_port);
+}
+
 /**
  * @brief socketからipアドレスの文字列を作成する
  * 
@@ -140,12 +164,8 @@ ssize_t	Utils::wrapperWrite( const int fd, const std::string& msg )
 std::string	Utils::socketToStrIPAddress( const int sock )
 {
 	struct sockaddr_in addr;
-	socklen_t	client_addrlen = sizeof(addr);
-	if (getsockname(sock, reinterpret_cast<struct sockaddr*>(&addr), &client_addrlen) == -1)
-	{
-		std::cerr << "webserv: [emerge] getsockname() \"" << sock << "\" failed (" << errno << ": " << strerror(errno) << ")" << std::endl;
+	if (!wrapperGetsockname(addr, sock))
 		return "";
-	}
 	return ipToStr(addr.sin_addr.s_addr);
 }
 

--- a/src/utils/Utils.cpp
+++ b/src/utils/Utils.cpp
@@ -5,7 +5,8 @@
 #include <unistd.h>
 #include <stdlib.h>
 #include <sys/param.h>
-
+#include <sys/socket.h>
+#include <netinet/in.h>
 
 int	Utils::wrapperOpen( const std::string path, int flags, mode_t modes )
 {
@@ -128,6 +129,24 @@ ssize_t	Utils::wrapperWrite( const int fd, const std::string& msg )
 		written_bytes += ret;
 	}
 	return written_bytes;
+}
+
+/**
+ * @brief socketからipアドレスの文字列を作成する
+ * 
+ * @param sock 
+ * @return std::string 
+ */
+std::string	Utils::socketToStrIPAddress( const int sock )
+{
+	struct sockaddr_in addr;
+	socklen_t	client_addrlen = sizeof(addr);
+	if (getsockname(sock, reinterpret_cast<struct sockaddr*>(&addr), &client_addrlen) == -1)
+	{
+		std::cerr << "webserv: [emerge] getsockname() \"" << sock << "\" failed (" << errno << ": " << strerror(errno) << ")" << std::endl;
+		return "";
+	}
+	return ipToStr(addr.sin_addr.s_addr);
 }
 
 std::string	Utils::ipToStr( const uint32_t ip )

--- a/src/utils/Utils.hpp
+++ b/src/utils/Utils.hpp
@@ -35,6 +35,7 @@ std::vector<std::string>	createDirectoryContents( const std::string& directoryPa
 bool	isExecutable( const char* filename );
 bool	isExtensionFile( const std::string& filename, const std::string& extension );
 ssize_t	wrapperWrite( const int fd, const std::string& msg );
+std::string	socketToStrIPAddress( const int sock );
 std::string	ipToStr( const uint32_t ip );
 uint32_t	StrToIPAddress( const std::string& ip);
 std::string	toLower(std::string str);

--- a/src/utils/Utils.hpp
+++ b/src/utils/Utils.hpp
@@ -11,6 +11,7 @@
 # include <vector>
 # include <algorithm>
 # include <stdint.h>
+#include <netinet/in.h>
 
 namespace Utils
 {
@@ -35,11 +36,22 @@ std::vector<std::string>	createDirectoryContents( const std::string& directoryPa
 bool	isExecutable( const char* filename );
 bool	isExtensionFile( const std::string& filename, const std::string& extension );
 ssize_t	wrapperWrite( const int fd, const std::string& msg );
+bool	wrapperGetsockname(struct sockaddr_in& addr, const int sock);
 std::string	socketToStrIPAddress( const int sock );
 std::string	ipToStr( const uint32_t ip );
 uint32_t	StrToIPAddress( const std::string& ip);
+int	resolveConnectedPort(const int sock);
 std::string	toLower(std::string str);
 bool	isSpace(const unsigned char ch);
+template<typename T>std::string	toStr(const T value);
+}
+
+template<typename T>
+std::string	Utils::toStr(const T value)
+{
+	std::stringstream	converter;
+	converter << value;
+	return converter.str();
 }
 
 #endif

--- a/test/cgi/CGIExecutor_test.cpp
+++ b/test/cgi/CGIExecutor_test.cpp
@@ -2,6 +2,7 @@
 #include <gtest/gtest-param-test.h>
 
 #include "CGIHandler.hpp"
+#include "ConnectionManager.hpp"
 
 #include <vector>
 #include <map>
@@ -219,8 +220,8 @@ TEST(cgi_executor, body)
 
 TEST(cgi_executor, meta_vars)
 {
-	cgi::CGIHandler	cgi_handler;
-	HttpRequest	request = test::initRequest(
+	ConnectionData	cd;
+	cd.request = test::initRequest(
 		config::REQUEST_METHOD::GET,
 		"/path/uri/",
 		"HTTP/1.1",
@@ -236,14 +237,14 @@ TEST(cgi_executor, meta_vars)
 	const std::string expect_header = "content-type: text/html\r\nStatus: 200 OK\r\n\r\n";
 	const std::string expect = expect_header + "<h1>env vars list</h1>"
 		+ "<h2>AUTH_TYPE=</h2>"
-		+ "<h2>CONTENT_LENGTH=" + std::to_string(request.body.size()) + "</h2>"
+		+ "<h2>CONTENT_LENGTH=" + std::to_string(cd.request.body.size()) + "</h2>"
 		+ "<h2>CONTENT_TYPE=text</h2>"
 		+ "<h2>GATEWAY_INTERFACE=CGI/1.1</h2>"
 		+ "<h2>PATH_INFO=</h2>"
 		+ "<h2>PATH_TRANSLATED=</h2>"
 		+ "<h2>QUERY_STRING=one=1&two=2&three=3</h2>"
-		+ "<h2>REMOTE_ADDR=client address</h2>"
-		+ "<h2>REMOTE_HOST=client address</h2>"
+		+ "<h2>REMOTE_ADDR=127.0.0.1</h2>"
+		+ "<h2>REMOTE_HOST=client host name</h2>"
 		+ "<h2>REQUEST_METHOD=GET</h2>"
 		+ "<h2>SCRIPT_NAME=/path/uri/</h2>"
 		+ "<h2>SERVER_NAME=tt</h2>"
@@ -252,9 +253,9 @@ TEST(cgi_executor, meta_vars)
 		+ "<h2>SERVER_SOFTWARE=webserv/1.0</h2>"
 	;
 	test::testCgiOutput(
-		cgi_handler,
+		cd.cgi_handler_,
 		"test/cgi/cgi_files/executor/meta_vars.py",
-		request,
+		cd.request,
 		expect
 	);
 }

--- a/test/cgi/CGIExecutor_test.cpp
+++ b/test/cgi/CGIExecutor_test.cpp
@@ -12,6 +12,7 @@
 #include <sys/types.h>
 #include <sys/socket.h>
 #include <sys/wait.h>
+#include <netinet/in.h>
 #include "Utils.hpp"
 #include <cstring>
 #include "LimitExcept.hpp"
@@ -238,17 +239,17 @@ TEST(cgi_executor, meta_vars)
 	const std::string expect = expect_header + "<h1>env vars list</h1>"
 		+ "<h2>AUTH_TYPE=</h2>"
 		+ "<h2>CONTENT_LENGTH=" + std::to_string(cd.request.body.size()) + "</h2>"
-		+ "<h2>CONTENT_TYPE=text</h2>"
+		+ "<h2>CONTENT_TYPE=text/html</h2>"
 		+ "<h2>GATEWAY_INTERFACE=CGI/1.1</h2>"
 		+ "<h2>PATH_INFO=</h2>"
 		+ "<h2>PATH_TRANSLATED=</h2>"
 		+ "<h2>QUERY_STRING=one=1&two=2&three=3</h2>"
-		+ "<h2>REMOTE_ADDR=127.0.0.1</h2>"
-		+ "<h2>REMOTE_HOST=client host name</h2>"
+		// + "<h2>REMOTE_ADDR=127.0.0.1</h2>" テスト不可のため、別のテストを追加
+		// + "<h2>REMOTE_HOST=127.0.0.1</h2>" テスト不可のため、別のテストを追加
 		+ "<h2>REQUEST_METHOD=GET</h2>"
 		+ "<h2>SCRIPT_NAME=/path/uri/</h2>"
 		+ "<h2>SERVER_NAME=tt</h2>"
-		+ "<h2>SERVER_PORT=</h2>"
+		// + "<h2>SERVER_PORT=4242</h2>" テスト不可のため、別のテストを追加
 		+ "<h2>SERVER_PROTOCOL=HTTP/1.1</h2>"
 		+ "<h2>SERVER_SOFTWARE=webserv/1.0</h2>"
 	;

--- a/test/cgi/cgi_files/executor/all_meta_vars.conf
+++ b/test/cgi/cgi_files/executor/all_meta_vars.conf
@@ -1,0 +1,8 @@
+events {}
+
+http {
+	root ./;
+	server {
+		listen 4242;
+	}
+}

--- a/test/cgi/cgi_files/executor/all_meta_vars.py
+++ b/test/cgi/cgi_files/executor/all_meta_vars.py
@@ -1,0 +1,35 @@
+#! /usr/bin/python3
+
+import os
+
+def	printEnvVar(env_name):
+      env_value = os.environ.get(env_name)
+      if env_value is None:
+             env_value = "not found"
+      print(env_name + "=" + env_value, end="\n")
+
+def	main():
+      print("\n", end="")
+      env_list = [
+            "AUTH_TYPE",
+            "CONTENT_LENGTH",
+            "CONTENT_TYPE",
+            "GATEWAY_INTERFACE",
+            "PATH_INFO",
+            "PATH_TRANSLATED",
+            "QUERY_STRING",
+            "REMOTE_ADDR",
+            "REMOTE_HOST",
+            "REQUEST_METHOD",
+            "SCRIPT_NAME",
+            "SERVER_NAME",
+            "SERVER_PORT",
+            "SERVER_PROTOCOL",
+            "SERVER_SOFTWARE"
+     ]
+ 
+      for env in env_list:
+             printEnvVar(env)
+
+if __name__ == "__main__":
+       main()

--- a/test/cgi/cgi_files/executor/meta_vars.py
+++ b/test/cgi/cgi_files/executor/meta_vars.py
@@ -19,12 +19,12 @@ def	main():
             "PATH_INFO",
             "PATH_TRANSLATED",
             "QUERY_STRING",
-            "REMOTE_ADDR",
-            "REMOTE_HOST",
+       #      "REMOTE_ADDR",
+       #      "REMOTE_HOST",
             "REQUEST_METHOD",
             "SCRIPT_NAME",
             "SERVER_NAME",
-            "SERVER_PORT",
+       #      "SERVER_PORT",
             "SERVER_PROTOCOL",
             "SERVER_SOFTWARE"
      ]

--- a/test/cgi/meta_vars_test.sh
+++ b/test/cgi/meta_vars_test.sh
@@ -1,0 +1,93 @@
+#!/bin/bash
+
+# init
+readonly script_dir_path=$(dirname "$0")
+readonly webserv_path="${script_dir_path}/../../webserv"
+readonly test_name="meta vars test"
+
+if [ -e $webserv_path ]
+then
+	printf "|------------------ $test_name start ------------------|\n"
+else
+	echo "${webserv_path}: command not found"
+	echo "run \"make\" first to test"
+	exit 1
+fi
+
+g_total_test=0
+g_test_index=0
+g_test_passed=0
+g_test_failed=0
+
+function	runServer {
+	$webserv_path $1 > /dev/null 2>&1 &
+	webserv_pid=$!
+}
+
+# responseのstatusをテスト
+function	assert {
+	g_total_test=$(bc <<< "$g_total_test + 1")
+	g_test_index=$(bc <<< "$g_test_index + 1")
+
+	local	uri=$1
+	local	request="localhost:4242/${uri}"
+	printf "[  test$g_test_index  ]\n${request}: "
+
+	# responseのtimeoutを1秒に設定 --max-time
+	local	actual=$(curl -H "host: test" -H "content-type: text" -d "body message" $request --max-time 1 2>/dev/null)
+	local	expect=$2
+	if [ "$actual" == "$expect" ]
+	then
+		printf "\033[32mpassed\033[0m\n\n"
+		g_test_passed=$(bc <<< "$g_test_passed + 1")
+	else
+		printf "\033[31mfailed\n\033[0m"
+		printf "expected:${expect}---\n"
+		printf "actual  :${actual}---\n\n"
+		g_test_failed=$(bc <<< "$g_test_failed + 1")
+	fi
+}
+
+function	printLog {
+	printf "\n|------------------ $test_name results ------------------|\n"
+	printf "[========]    ${g_total_test} tests ran\n"
+	printf "[ \033[32mPASSED\033[0m ]    ${g_test_passed} tests\n"
+	printf "[ \033[31mFAILED\033[0m ]    ${g_test_failed} tests\n"
+
+	if [ $g_test_failed -ne 0 ]
+	then
+		exit 1
+	fi
+}
+
+runServer "${root}/all_meta_vars.conf"
+
+root="test/cgi/cgi_files/executor"
+uri="${root}/all_meta_vars.py"
+
+meta_vars=(
+	"AUTH_TYPE=\n"
+	"CONTENT_LENGTH=12\n"
+	"CONTENT_TYPE=text\n"
+	"GATEWAY_INTERFACE=CGI/1.1\n"
+	"PATH_INFO=\n"
+	"PATH_TRANSLATED=\n"
+	"QUERY_STRING=key=value&test=vtest\n"
+	"REMOTE_ADDR=127.0.0.1\n"
+	"REMOTE_HOST=127.0.0.1\n"
+	"REQUEST_METHOD=GET\n"
+	"SCRIPT_NAME=${uri}\n"
+	"SERVER_NAME=test\n"
+	"SERVER_PORT=4242\n"
+	"SERVER_PROTOCOL=HTTP/1.1\n"
+	"SERVER_SOFTWARE=webserv/1.0\n"
+)
+
+expect=$(printf "%s" "${meta_vars[@]}")
+
+assert "${root}/${uri}?key=value&test=vtest" "${expect}"
+
+# サーバープロセスを終了
+kill $webserv_pid > /dev/null 2>&1
+
+printLog

--- a/test/server/HttpRequestOkTest.cpp
+++ b/test/server/HttpRequestOkTest.cpp
@@ -17,7 +17,7 @@ void checkHttpRequestEqual(HttpRequest expect, HttpRequest test)
 TEST(HttpRequest, OkTest1)
 {
     //testcase: リクエストラインだけ -> Hostヘッダーは無いとエラーなので追加.
-    std::map<std::string, std::string> headers;
+    std::map<std::string, std::string, Utils::CaseInsensitiveCompare> headers;
     headers["Host"] = "aa";
     HttpRequest expect(config::GET, "/", "HTTP/1.1", headers, "", "", HttpRequest::PARSE_COMPLETE);
 
@@ -33,7 +33,7 @@ TEST(HttpRequest, OkTest2)
 {
     //testcase: header fieldが一対ある時
     //testcase: bodyもある
-    std::map<std::string, std::string> headers;
+    std::map<std::string, std::string, Utils::CaseInsensitiveCompare> headers;
     headers["Host"] = "aa";
     HttpRequest expect(config::GET, "/", "HTTP/1.1", headers, "", "this is body", HttpRequest::PARSE_COMPLETE);
 
@@ -51,7 +51,7 @@ TEST(HttpRequest, OkTest2)
 TEST(HttpRequest, OkTest3)
 {
     //testcase: header fieldが複数ある時
-    std::map<std::string, std::string> headers;
+    std::map<std::string, std::string, Utils::CaseInsensitiveCompare> headers;
     headers["Host"] = "aa";
     headers["name1"] = "value1";
     headers["name2"] = "value2";
@@ -72,7 +72,7 @@ TEST(HttpRequest, OkTest3)
 TEST(HttpRequest, OkTest4)
 {
     //testcase: query stringが単体
-    std::map<std::string, std::string> headers;
+    std::map<std::string, std::string, Utils::CaseInsensitiveCompare> headers;
     headers["Host"] = "aa";
     HttpRequest expect(config::GET, "/html", "HTTP/1.1", headers, "query1=value1", "", HttpRequest::PARSE_COMPLETE);
 
@@ -87,7 +87,7 @@ TEST(HttpRequest, OkTest4)
 TEST(HttpRequest, OkTest5)
 {
     //testcase: query stringが複数ある時
-    std::map<std::string, std::string> headers;
+    std::map<std::string, std::string, Utils::CaseInsensitiveCompare> headers;
     headers["Host"] = "aa";
     HttpRequest expect(config::GET, "/html", "HTTP/1.1", headers, "query1=value1&query2=value2", "", HttpRequest::PARSE_COMPLETE);
 
@@ -102,7 +102,7 @@ TEST(HttpRequest, OkTest5)
 TEST(HttpRequest, OkTest6)
 {
     //testcase: chunked first
-    std::map<std::string, std::string> headers;
+    std::map<std::string, std::string, Utils::CaseInsensitiveCompare> headers;
     headers["Host"] = "aa";
     headers["Transfer-Encoding"] = "chunked";
     HttpRequest expect(config::GET, "/html", "HTTP/1.1", headers, "", "hello", HttpRequest::PARSE_INPROGRESS);
@@ -124,7 +124,7 @@ TEST(HttpRequest, OkTest6)
 TEST(HttpRequest, OkTest7)
 {
     //testcase: chunked first
-    std::map<std::string, std::string> headers;
+    std::map<std::string, std::string, Utils::CaseInsensitiveCompare> headers;
     headers["Host"] = "aa";
     headers["Transfer-Encoding"] = "chunked";
     HttpRequest expect(config::GET, "/html", "HTTP/1.1", headers, "", "hello", HttpRequest::PARSE_INPROGRESS);
@@ -153,7 +153,7 @@ TEST(HttpRequest, OkTest7)
 TEST(HttpRequest, OkTest8)
 {
     //testcase: chunked first
-    std::map<std::string, std::string> headers;
+    std::map<std::string, std::string, Utils::CaseInsensitiveCompare> headers;
     headers["Host"] = "aa";
     headers["Transfer-Encoding"] = "chunked";
     HttpRequest expect(config::GET, "/html", "HTTP/1.1", headers, "", "hello", HttpRequest::PARSE_INPROGRESS);
@@ -189,7 +189,7 @@ TEST(HttpRequest, OkTest8)
 TEST(HttpRequest, OkTest9)
 {
     //testcase: encoded url
-    std::map<std::string, std::string> headers;
+    std::map<std::string, std::string, Utils::CaseInsensitiveCompare> headers;
     headers["Host"] = "aa";
     HttpRequest expect(config::GET, "/Hello World!", "HTTP/1.1", headers, "", "", HttpRequest::PARSE_COMPLETE);
 
@@ -204,7 +204,7 @@ TEST(HttpRequest, OkTest9)
 TEST(HttpRequest, OkTest10)
 {
     //testcase: POSTをパースできるか
-    std::map<std::string, std::string> headers;
+    std::map<std::string, std::string, Utils::CaseInsensitiveCompare> headers;
     headers["Host"] = "aa";
     HttpRequest expect(config::POST, "/", "HTTP/1.1", headers, "", "", HttpRequest::PARSE_COMPLETE);
 
@@ -219,7 +219,7 @@ TEST(HttpRequest, OkTest10)
 TEST(HttpRequest, OkTest11)
 {
     //testcase: HEADをパースできるか.
-    std::map<std::string, std::string> headers;
+    std::map<std::string, std::string, Utils::CaseInsensitiveCompare> headers;
     headers["Host"] = "aa";
     HttpRequest expect(config::HEAD, "/", "HTTP/1.1", headers, "", "", HttpRequest::PARSE_COMPLETE);
 
@@ -234,7 +234,7 @@ TEST(HttpRequest, OkTest11)
 TEST(HttpRequest, OkTest12)
 {
     //testcase: HEADをパースできるか.
-    std::map<std::string, std::string> headers;
+    std::map<std::string, std::string, Utils::CaseInsensitiveCompare> headers;
     headers["Host"] = "aa";
     HttpRequest expect(config::HEAD, "/", "HTTP/1.1", headers, "", "", HttpRequest::PARSE_COMPLETE);
 
@@ -249,7 +249,7 @@ TEST(HttpRequest, OkTest12)
 TEST(HttpRequest, OkTest13)
 {
     //testcase: DELETEをパースできるか.
-    std::map<std::string, std::string> headers;
+    std::map<std::string, std::string, Utils::CaseInsensitiveCompare> headers;
     headers["Host"] = "aa";
     HttpRequest expect(config::DELETE, "/", "HTTP/1.1", headers, "", "", HttpRequest::PARSE_COMPLETE);
 


### PR DESCRIPTION
# 対応内容
- http request
  - headerのkeyを大文字小文字の差異を区別しないように修正
- cgi
  - 上記の対応に伴うメタ変数の処理を修正
  - テストを追加（現状動かない）
  →cgiのリクエストが通るようになれば、テスト実施可能になる