### PR TITLE
worker_connectionsに従って古い接続削除

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,11 +26,23 @@ add_executable(${PROJECT_NAME}-googletest
 	src/server/CGIParser.cpp
 	src/server/CGIExecutor.cpp
 	src/server/ConfigHandler.cpp
+	src/server/ConnectionManager.cpp
 	src/server/HttpRequest.cpp
 	src/server/HttpResponse.cpp
+	src/server/NetworkIOHandler.cpp
+	src/server/RequestHandler.cpp
 	src/server/SysCallWrapper.cpp
 	src/server/Timer.cpp
 	src/server/TimerTree.cpp
+	src/server/EpollActiveEventManager.cpp
+	src/server/EpollServer.cpp
+	src/server/PollActiveEventManager.cpp
+	src/server/PollServer.cpp
+	src/server/KqueueActiveEventManager.cpp
+	src/server/KqueueServer.cpp
+	src/server/SelectActiveEventManager.cpp
+	src/server/SelectServer.cpp
+	src/server/WebServer.cpp
 	src/utils/Utils.cpp
 	
 	# test files
@@ -40,6 +52,7 @@ add_executable(${PROJECT_NAME}-googletest
 	test/server/HttpRequestErrorTest.cpp 
 	test/server/HttpRequestOkTest.cpp 
 	test/server/HttpResponseTest.cpp
+	test/server/WorkerConnectionsNumTest.cpp
 	test/conf/confLexerTest.cpp 
 	test/conf/directives_test.cpp 
 	test/conf/main_parser_test.cpp 

--- a/src/config/Parser.cpp
+++ b/src/config/Parser.cpp
@@ -706,12 +706,7 @@ bool	config::Parser::parseWorkerConnections()
 	// 値が正の数かつLONG_MAX以内でなければエラー
 	if (iss >> value)
 	{
-		if (0 == value || value == 1) // 本当はserver側で弾く
-		{
-			std::cerr << "webserv: [emerg] \"" << value << "\" worker_connections are not enough for 1 listening sockets" << std::endl;
-			return false;
-		}
-		else if (value < 0)
+		if (value < 0)
 		{
 			std::cerr << "webserv: [emerg] invalid number \"" << this->tokens_[ti_].value_ << "\" in " << this->filepath_ << ":" << this->tokens_[ti_].line_ << std::endl;
 			return false;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -22,6 +22,7 @@ int main(int ac, char *av[])
 		server.run();
 	}
 	catch (const std::exception& e) {
+		std::cerr << e.what() << std::endl;
 		return 1;
 	}
 	return 1;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -23,7 +23,6 @@ int main(int ac, char *av[])
 	}
 	catch (const std::exception& e) {
 		std::cerr << e.what() << std::endl;
-		return 1;
 	}
 	return 1;
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -17,8 +17,13 @@ int main(int ac, char *av[])
 	if (config == NULL)
 		return 1;
 
-	WebServer server = WebServer(config);
-	server.run();
+	try {
+		WebServer server = WebServer(config);
+		server.run();
+	}
+	catch (const std::exception& e) {
+		return 1;
+	}
 	return 1;
 }
 

--- a/src/server/CGIHandler.hpp
+++ b/src/server/CGIHandler.hpp
@@ -25,7 +25,6 @@ class CGIHandler
 		CGIExecutor	cgi_executor_;
 		int	cli_socket_; // cgiが紐づくクライアント
 		pid_t	cgi_process_id_;
-		int	cli_socket_; // cgiが紐づくクライアント
 		bool	forkCgiProcess(
 			const HttpRequest& request,
 			const std::string& script_path

--- a/src/server/ConnectionManager.cpp
+++ b/src/server/ConnectionManager.cpp
@@ -17,7 +17,7 @@ ConnectionManager::~ConnectionManager()
 void ConnectionManager::setConnection( const int fd )
 {
 	connections_[fd] = new ConnectionData();
-	std::cerr << "new connection:" << fd << "\n";
+	std::cout << "new connection:" << fd << "\n";
 }
 
 /**

--- a/src/server/RequestHandler.cpp
+++ b/src/server/RequestHandler.cpp
@@ -27,7 +27,7 @@ int RequestHandler::handleReadEvent(NetworkIOHandler &ioHandler, ConnectionManag
 		this->addTimerByType(ioHandler, connManager, configHandler, timerTree, sockfd, Timer::TMO_CLI_REQUEST);
 
 		// worker_connections確認
-		if (isOverWorkerConnections(connManager, configHandler))
+		if (this->isOverWorkerConnections(connManager, configHandler))
 			this->deleteTimerAndConnection(ioHandler, connManager, timerTree, timerTree.getTimerTree().begin()->getFd());
 
 		return accept_sock;
@@ -261,7 +261,7 @@ void	RequestHandler::deleteTimerAndConnection(NetworkIOHandler &ioHandler, Conne
 	ioHandler.closeConnection(connManager, socket);
 }
 
-bool	isOverWorkerConnections(ConnectionManager &connManager, ConfigHandler &configHandler)
+bool	RequestHandler::isOverWorkerConnections(ConnectionManager &connManager, ConfigHandler &configHandler)
 {
 	return connManager.getConnections().size() >= configHandler.config_->events.worker_connections.getWorkerConnections();
 }

--- a/src/server/RequestHandler.cpp
+++ b/src/server/RequestHandler.cpp
@@ -7,8 +7,6 @@
 #include <sys/time.h>
 #include <sys/resource.h>
 
-bool	isOverWorkerConnections(ConnectionManager &connManager, ConfigHandler &configHandler);
-
 RequestHandler::RequestHandler() {}
 
 int RequestHandler::handleReadEvent(NetworkIOHandler &ioHandler, ConnectionManager &connManager, ConfigHandler &configHandler, TimerTree &timerTree, const int sockfd)

--- a/src/server/RequestHandler.cpp
+++ b/src/server/RequestHandler.cpp
@@ -28,7 +28,7 @@ int RequestHandler::handleReadEvent(NetworkIOHandler &ioHandler, ConnectionManag
 
 		// worker_connections確認
 		if (isOverWorkerConnections(connManager, configHandler))
-			deleteTimerAndConnection(ioHandler, connManager, timerTree, timerTree.getTimerTree().begin()->getFd());
+			this->deleteTimerAndConnection(ioHandler, connManager, timerTree, timerTree.getTimerTree().begin()->getFd());
 
 		return accept_sock;
 	}
@@ -152,7 +152,7 @@ void	RequestHandler::handleTimeoutEvent(NetworkIOHandler &ioHandler, ConnectionM
 		std::multiset<Timer>::iterator next = it;
 		next++;
 		// timer tree から削除
-		deleteTimerAndConnection(ioHandler, connManager, timerTree, it->getFd());
+		this->deleteTimerAndConnection(ioHandler, connManager, timerTree, it->getFd());
 		// timeoutの種類によってログ出力変える
 		//std::string	timeout_reason = "waiting for client request.";
 		configHandler.writeErrorLog("webserv: [info] client timed out\n");

--- a/src/server/RequestHandler.cpp
+++ b/src/server/RequestHandler.cpp
@@ -35,6 +35,7 @@ int RequestHandler::handleReadEvent(NetworkIOHandler &ioHandler, ConnectionManag
 			// もしCGIソケットなら紐づくclientソケットも削除
 			if (connManager.isCgiSocket(oldest_sock))
 			{
+				connManager.getCgiHandler(oldest_sock).killCgiProcess();
 				int tied_sock = connManager.getCgiHandler(oldest_sock).getCliSocket();
 				ioHandler.closeConnection(connManager, tied_sock);
 				timerTree.deleteTimer(tied_sock);
@@ -195,6 +196,7 @@ void	RequestHandler::handleTimeoutEvent(NetworkIOHandler &ioHandler, ConnectionM
 		int client_sock = it->getFd();
 		if (connManager.isCgiSocket(client_sock))
 		{
+			connManager.getCgiHandler(client_sock).killCgiProcess();
 			int tied_sock = connManager.getCgiHandler(client_sock).getCliSocket();
 			ioHandler.closeConnection(connManager, tied_sock);
 			// ToDo: client socketとcgiソケットが同時にセットされるか？

--- a/src/server/RequestHandler.hpp
+++ b/src/server/RequestHandler.hpp
@@ -33,12 +33,13 @@ class RequestHandler
 		int handleCgiReadEvent(NetworkIOHandler &ioHandler, ConnectionManager &connManager, ConfigHandler& configHandler, const int sockfd);
 		int handleCgiWriteEvent(NetworkIOHandler &ioHandler, ConnectionManager &connManager, const int sockfd);
 		int handleErrorEvent(NetworkIOHandler &ioHandler, ConnectionManager &connManager, TimerTree &timerTree, const int sockfd);
-		void handleTimeoutEvent(NetworkIOHandler &ioHandler, ConnectionManager &connManager, ConfigHandler &configHandler, TimerTree &timer_tree);
+		void handleTimeoutEvent(NetworkIOHandler &ioHandler, ConnectionManager &connManager, ConfigHandler &configHandler, TimerTree &timerTree);
 
 	private:
 		bool cgiProcessExited(const pid_t process_id) const;
 		int	handleResponse(ConnectionManager &connManager, ConfigHandler& configHandler, const int sockfd);
 		bool	addTimerSafely(NetworkIOHandler &ioHandler, ConnectionManager &connManager, ConfigHandler &configHandler, TimerTree &timerTree, const int sockfd, enum Timer::TimeoutType type);
+		void	deleteTimerAndConnection(NetworkIOHandler &ioHandler, ConnectionManager &connManager, TimerTree &timerTree, int socket);
 };
 
 #endif

--- a/src/server/RequestHandler.hpp
+++ b/src/server/RequestHandler.hpp
@@ -38,6 +38,7 @@ class RequestHandler
 	private:
 		bool cgiProcessExited(const pid_t process_id) const;
 		int	handleResponse(ConnectionManager &connManager, ConfigHandler& configHandler, const int sockfd);
+		bool	addTimerSafely(NetworkIOHandler &ioHandler, ConnectionManager &connManager, ConfigHandler &configHandler, TimerTree &timerTree, const int sockfd, enum Timer::TimeoutType type);
 };
 
 #endif

--- a/src/server/RequestHandler.hpp
+++ b/src/server/RequestHandler.hpp
@@ -40,6 +40,7 @@ class RequestHandler
 		int	handleResponse(ConnectionManager &connManager, ConfigHandler& configHandler, const int sockfd);
 		bool	addTimerByType(NetworkIOHandler &ioHandler, ConnectionManager &connManager, ConfigHandler &configHandler, TimerTree &timerTree, const int sockfd, enum Timer::TimeoutType type);
 		void	deleteTimerAndConnection(NetworkIOHandler &ioHandler, ConnectionManager &connManager, TimerTree &timerTree, int socket);
+		bool	isOverWorkerConnections(ConnectionManager &connManager, ConfigHandler &configHandler);
 };
 
 #endif

--- a/src/server/RequestHandler.hpp
+++ b/src/server/RequestHandler.hpp
@@ -38,7 +38,7 @@ class RequestHandler
 	private:
 		bool cgiProcessExited(const pid_t process_id) const;
 		int	handleResponse(ConnectionManager &connManager, ConfigHandler& configHandler, const int sockfd);
-		bool	addTimerSafely(NetworkIOHandler &ioHandler, ConnectionManager &connManager, ConfigHandler &configHandler, TimerTree &timerTree, const int sockfd, enum Timer::TimeoutType type);
+		bool	addTimerByType(NetworkIOHandler &ioHandler, ConnectionManager &connManager, ConfigHandler &configHandler, TimerTree &timerTree, const int sockfd, enum Timer::TimeoutType type);
 		void	deleteTimerAndConnection(NetworkIOHandler &ioHandler, ConnectionManager &connManager, TimerTree &timerTree, int socket);
 };
 

--- a/src/server/Timer.hpp
+++ b/src/server/Timer.hpp
@@ -23,6 +23,12 @@ class Timer
 		void	setTimeout(const config::Time &time);
 		static unsigned long	getCurrentTime();
 		static void	updateCurrentTime();
+		enum TimeoutType {
+			KEEPALIVE_TIMEOUT,
+			REQUEST_TIMEOUT,
+			SEND_TIMEOUT,
+			OTHER_TIMEOUT
+		};
 };
 
 #endif

--- a/src/server/Timer.hpp
+++ b/src/server/Timer.hpp
@@ -24,10 +24,9 @@ class Timer
 		static unsigned long	getCurrentTime();
 		static void	updateCurrentTime();
 		enum TimeoutType {
-			KEEPALIVE_TIMEOUT,
-			REQUEST_TIMEOUT,
-			SEND_TIMEOUT,
-			OTHER_TIMEOUT
+			TMO_KEEPALIVE,
+			TMO_CLI_REQUEST,
+			TMO_SEND,
 		};
 };
 

--- a/src/server/WebServer.cpp
+++ b/src/server/WebServer.cpp
@@ -13,17 +13,10 @@ WebServer::WebServer( const config::Main* config )
 	this->initializeServer();
 	if (this->ioHandler->getListenfdMap().size() >= this->configHandler->config_->events.worker_connections.getWorkerConnections())
 	{
-		std::cout << "webserv: [emerg] " << this->configHandler->config_->events.worker_connections.getWorkerConnections() << " worker_connections are not enough for " << this->ioHandler->getListenfdMap().size() << " listening sockets" << std::endl;
-		delete this->timerTree;
-		config::terminateLogFds(this->configHandler->config_);
-		delete this->configHandler->config_;
-		delete this->configHandler;
-		delete this->ioHandler;
-		delete this->requestHandler;
-		delete this->connManager;
-		delete this->eventManager;
-		delete this->server;
-		throw std::exception();
+		std::stringstream	ss;
+		ss << "webserv: [emerg] " << this->configHandler->config_->events.worker_connections.getWorkerConnections() << " worker_connections are not enough for " << this->ioHandler->getListenfdMap().size() << " listening sockets";
+		this->deleteObjects();
+		throw std::runtime_error(ss.str());
 	}
 }
 
@@ -134,6 +127,11 @@ WebServer::~WebServer()
 {
 	this->configHandler->writeErrorLog("webserv: [debug] Close webserv.\n\n");
 	// close( this->connManager->getConnection() ); // 一応eventLoop()でもクローズしているけど、シグナルで終了した時、逐次処理で行なっているクライアントソケットのクローズが行われていない可能性があるので入れた。
+	this->deleteObjects();
+}
+
+void	WebServer::deleteObjects()
+{
 	config::terminateLogFds(this->configHandler->config_);
 	delete this->timerTree;
 	delete this->configHandler->config_;

--- a/src/server/WebServer.hpp
+++ b/src/server/WebServer.hpp
@@ -37,6 +37,7 @@ class WebServer
 		void	initializeListenSocket(std::set<std::pair<std::string, unsigned int> > &ip_address_set,
 										const std::string address, const unsigned int port);
 		void	initializeConnManager();
+		void	deleteObjects();
 };
 
 #endif

--- a/test/server/WorkerConnectionsNumTest.cpp
+++ b/test/server/WorkerConnectionsNumTest.cpp
@@ -1,0 +1,73 @@
+#include <gtest/gtest.h>
+#include <gtest/gtest-param-test.h>
+#include <gtest/internal/gtest-port.h>
+#include "conf.hpp"
+#include "WebServer.hpp"
+#include <iostream>
+
+class WorkerConnectionsNumTest : public ::testing::Test {
+protected:
+    // 各TESTの前に呼び出されるセットアップメソッド
+	void SetUp() override {
+		std::string		file_path;
+		const testing::TestInfo*	test_info = testing::UnitTest::GetInstance()->current_test_info();
+		if (static_cast<std::string>(test_info->name()) == "OK") {
+			file_path = "test/server/WorkerConnectionsNumTestFiles/OK.conf";
+		}
+		else if (static_cast<std::string>(test_info->name()) == "ERROR_MORE_THAN_MAX") {
+			file_path = "test/server/WorkerConnectionsNumTestFiles/ERROR_MORE_THAN_MAX.conf";
+		}
+		else if (static_cast<std::string>(test_info->name()) == "ERROR_EQ_MAX") {
+			file_path = "test/server/WorkerConnectionsNumTestFiles/ERROR_EQ_MAX.conf";
+		}
+		else {
+			this->config_ = new config::Main();
+			GTEST_SKIP();
+		}
+
+		this->config_ = config::initConfig(file_path);
+	}
+
+	void TearDown() override {
+		// テストケースのクリーンアップ処理
+	}
+
+	config::Main*	config_;
+};
+
+TEST_F(WorkerConnectionsNumTest, OK)
+{
+	testing::internal::CaptureStdout();
+	ASSERT_NO_THROW(WebServer(this->config_));
+	testing::internal::GetCapturedStdout();
+}
+
+TEST_F(WorkerConnectionsNumTest, ERROR_EQ_MAX)
+{
+	testing::internal::CaptureStdout();
+	try
+	{
+		WebServer	server(this->config_);
+		FAIL();
+	}
+	catch( const std::exception& err )
+	{
+		ASSERT_STREQ("webserv: [emerg] 5 worker_connections are not enough for 5 listening sockets", err.what());
+	}
+	testing::internal::GetCapturedStdout();
+}
+
+TEST_F(WorkerConnectionsNumTest, ERROR_MORE_THAN_MAX)
+{
+	testing::internal::CaptureStdout();
+	try
+	{
+		WebServer	server(this->config_);
+		FAIL();
+	}
+	catch( const std::exception& err )
+	{
+		ASSERT_STREQ("webserv: [emerg] 5 worker_connections are not enough for 6 listening sockets", err.what());
+	}
+	testing::internal::GetCapturedStdout();
+}

--- a/test/server/WorkerConnectionsNumTest.cpp
+++ b/test/server/WorkerConnectionsNumTest.cpp
@@ -37,6 +37,7 @@ protected:
 
 TEST_F(WorkerConnectionsNumTest, OK)
 {
+	// test_file: "test/server/WorkerConnectionsNumTestFiles/OK.conf";
 	testing::internal::CaptureStdout();
 	ASSERT_NO_THROW(WebServer(this->config_));
 	testing::internal::GetCapturedStdout();
@@ -44,6 +45,7 @@ TEST_F(WorkerConnectionsNumTest, OK)
 
 TEST_F(WorkerConnectionsNumTest, ERROR_EQ_MAX)
 {
+	// test_file: "test/server/WorkerConnectionsNumTestFiles/ERROR_EQ_MAX.conf";
 	testing::internal::CaptureStdout();
 	try
 	{
@@ -59,6 +61,7 @@ TEST_F(WorkerConnectionsNumTest, ERROR_EQ_MAX)
 
 TEST_F(WorkerConnectionsNumTest, ERROR_MORE_THAN_MAX)
 {
+	// test_file: "test/server/WorkerConnectionsNumTestFiles/ERROR_MORE_THAN_MAX.conf";
 	testing::internal::CaptureStdout();
 	try
 	{

--- a/test/server/WorkerConnectionsNumTestFiles/ERROR_EQ_MAX.conf
+++ b/test/server/WorkerConnectionsNumTestFiles/ERROR_EQ_MAX.conf
@@ -1,0 +1,19 @@
+events {
+	worker_connections 5;
+}
+
+http {
+	server {
+		listen 127.0.0.1:8001 default_server;
+		listen 127.0.0.1:8002 default_server;
+		listen 127.0.0.1:8004;
+		server_name first_server;
+	}
+	server {
+		listen 127.0.0.1:8002;
+		listen 127.0.0.1:8003 default_server;
+		listen 127.0.0.1:8004 default_server;
+		listen 127.0.0.1:8005 default_server;
+		server_name second_server;
+	}
+}

--- a/test/server/WorkerConnectionsNumTestFiles/ERROR_MORE_THAN_MAX.conf
+++ b/test/server/WorkerConnectionsNumTestFiles/ERROR_MORE_THAN_MAX.conf
@@ -1,0 +1,20 @@
+events {
+	worker_connections 5;
+}
+
+http {
+	server {
+		listen 127.0.0.1:8001 default_server;
+		listen 127.0.0.1:8002 default_server;
+		listen 127.0.0.1:8004;
+		listen 127.0.0.1:8006 default_server;
+		server_name first_server;
+	}
+	server {
+		listen 127.0.0.1:8002;
+		listen 127.0.0.1:8003 default_server;
+		listen 127.0.0.1:8004 default_server;
+		listen 127.0.0.1:8005 default_server;
+		server_name second_server;
+	}
+}

--- a/test/server/WorkerConnectionsNumTestFiles/OK.conf
+++ b/test/server/WorkerConnectionsNumTestFiles/OK.conf
@@ -1,0 +1,19 @@
+events {
+	worker_connections 6;
+}
+
+http {
+	server {
+		listen 127.0.0.1:8001 default_server;
+		listen 127.0.0.1:8002 default_server;
+		listen 127.0.0.1:8004;
+		server_name first_server;
+	}
+	server {
+		listen 127.0.0.1:8002;
+		listen 127.0.0.1:8003 default_server;
+		listen 127.0.0.1:8004 default_server;
+		listen 127.0.0.1:8005 default_server;
+		server_name second_server;
+	}
+}


### PR DESCRIPTION
### worker_connections 挙動
新規接続を受け付ける
クライアント数 + 受付ソケット数 >= worker_connections
であれば、新規接続のためにTimerTreeで一番古い接続を削除する。

listen socket >= worker_connectionsだったらWebserverのコンストラクタで例外を投げることにしました。
この対応でよいかは少し迷っています。
runする前に判定したいですが、listenソケットを作るまで実際何個のlistenソケットを作り出すかわからないので（configに同じaddress::portが複数あることもあるから）、initializeListenSocketの後でないと判定できないと思っています。

### ToDo
- [ ] callCgiExecutorで socketpairしたときの返り値をみて成功していればworker_connectionsをチェック。-> issue137がmergeされてからやるので次のbranchで対応