### PR TITLE
Issue197 modify script name

### DIFF
--- a/src/server/CGIExecutor.cpp
+++ b/src/server/CGIExecutor.cpp
@@ -32,7 +32,8 @@ void cgi::CGIExecutor::executeCgiScript(const HttpRequest& request, const HttpRe
 }
 
 void cgi::CGIExecutor::prepareCgiExecution(const HttpRequest& request, const HttpResponse& response,
-                                           const std::string& full_path, const int cgi_sock, const int cli_sock) {
+                                           const std::string& full_path, const int cgi_sock,
+                                           const int cli_sock) {
   if (!redirectStdIOToSocket(request, cgi_sock)) std::exit(EXIT_FAILURE);
   createScriptPath(full_path);
   createArgv(full_path);

--- a/src/server/CGIExecutor.cpp
+++ b/src/server/CGIExecutor.cpp
@@ -22,7 +22,8 @@ cgi::CGIExecutor::~CGIExecutor() {}
 
 void cgi::CGIExecutor::executeCgiScript(const HttpRequest& request, const HttpResponse& response,
                                         const int cgi_sock, const int cli_sock) {
-  prepareCgiExecution(request, response, cgi_sock, cli_sock);
+  std::string full_path = response.root_path_ + response.res_file_path_;
+  prepareCgiExecution(request, response, full_path, cgi_sock, cli_sock);
   execve(this->script_path_.c_str(), const_cast<char* const*>(this->argv_.data()),
          const_cast<char* const*>(this->meta_vars_.data()));
   std::cerr << "webserv: [emerg] execve() failed (" << errno << ": " << std::strerror(errno) << ")"
@@ -31,10 +32,10 @@ void cgi::CGIExecutor::executeCgiScript(const HttpRequest& request, const HttpRe
 }
 
 void cgi::CGIExecutor::prepareCgiExecution(const HttpRequest& request, const HttpResponse& response,
-                                           const int cgi_sock, const int cli_sock) {
+                                           const std::string& full_path, const int cgi_sock, const int cli_sock) {
   if (!redirectStdIOToSocket(request, cgi_sock)) std::exit(EXIT_FAILURE);
-  createScriptPath(response.root_path_ + response.res_file_path_);
-  createArgv(response.root_path_ + response.res_file_path_);
+  createScriptPath(full_path);
+  createArgv(full_path);
   createMetaVars(request, response, cli_sock);
 }
 

--- a/src/server/CGIExecutor.cpp
+++ b/src/server/CGIExecutor.cpp
@@ -33,9 +33,9 @@ void cgi::CGIExecutor::executeCgiScript(const HttpRequest& request, const HttpRe
 void cgi::CGIExecutor::prepareCgiExecution(const HttpRequest& request, const HttpResponse& response,
                                            const int cgi_sock, const int cli_sock) {
   if (!redirectStdIOToSocket(request, cgi_sock)) std::exit(EXIT_FAILURE);
-  createScriptPath(response.res_file_path_);
-  createArgv(response.res_file_path_);
-  createMetaVars(request, response.path_info_, cli_sock);
+  createScriptPath(response.root_path_ + response.res_file_path_);
+  createArgv(response.root_path_ + response.res_file_path_);
+  createMetaVars(request, response, cli_sock);
 }
 
 void cgi::CGIExecutor::createScriptPath(const std::string& script_path) {
@@ -60,7 +60,7 @@ void cgi::CGIExecutor::createArgv(const std::string& script_path) {
   this->argv_.push_back(NULL);
 }
 
-void cgi::CGIExecutor::createMetaVars(const HttpRequest& request, const std::string& path_info,
+void cgi::CGIExecutor::createMetaVars(const HttpRequest& request, const HttpResponse& response,
                                       const int cli_sock) {
   const static char* kContentType = "content-type";
 
@@ -78,7 +78,7 @@ void cgi::CGIExecutor::createMetaVars(const HttpRequest& request, const std::str
   this->meta_vars_.push_back("GATEWAY_INTERFACE=CGI/1.1");
 
   static std::string path_info_var = "PATH_INFO=";
-  if (!path_info.empty()) path_info_var += path_info;
+  if (!response.path_info_.empty()) path_info_var += response.path_info_;
   this->meta_vars_.push_back(path_info_var.c_str());
 
   this->meta_vars_.push_back(
@@ -99,7 +99,7 @@ void cgi::CGIExecutor::createMetaVars(const HttpRequest& request, const std::str
       std::string("REQUEST_METHOD=") + config::LimitExcept::MethodToStr(request.method);
   this->meta_vars_.push_back(method.c_str());
 
-  const static std::string script_name = std::string("SCRIPT_NAME=") + request.uri;
+  const static std::string script_name = std::string("SCRIPT_NAME=") + response.res_file_path_;
   this->meta_vars_.push_back(script_name.c_str());
 
   const static std::string server_name = std::string("SERVER_NAME=") + request.headers.at("host");

--- a/src/server/CGIExecutor.hpp
+++ b/src/server/CGIExecutor.hpp
@@ -13,8 +13,8 @@ class CGIExecutor {
   std::string script_path_;
   std::vector<const char*> argv_;
   std::vector<const char*> meta_vars_;  // メタ変数(環境変数)
-  void prepareCgiExecution(const HttpRequest& request, const HttpResponse& response, const int cgi_sock,
-                           const int cli_sock);
+  void prepareCgiExecution(const HttpRequest& request, const HttpResponse& response, const std::string& full_path,
+                           const int cgi_sock, const int cli_sock);
   void createScriptPath(const std::string& script_path);
   void createArgv(const std::string& script_path);
   void createMetaVars(const HttpRequest& request, const HttpResponse& response, const int cli_sock);

--- a/src/server/CGIExecutor.hpp
+++ b/src/server/CGIExecutor.hpp
@@ -13,8 +13,8 @@ class CGIExecutor {
   std::string script_path_;
   std::vector<const char*> argv_;
   std::vector<const char*> meta_vars_;  // メタ変数(環境変数)
-  void prepareCgiExecution(const HttpRequest& request, const HttpResponse& response, const std::string& full_path,
-                           const int cgi_sock, const int cli_sock);
+  void prepareCgiExecution(const HttpRequest& request, const HttpResponse& response,
+                           const std::string& full_path, const int cgi_sock, const int cli_sock);
   void createScriptPath(const std::string& script_path);
   void createArgv(const std::string& script_path);
   void createMetaVars(const HttpRequest& request, const HttpResponse& response, const int cli_sock);

--- a/src/server/CGIExecutor.hpp
+++ b/src/server/CGIExecutor.hpp
@@ -17,7 +17,7 @@ class CGIExecutor {
                            const int cli_sock);
   void createScriptPath(const std::string& script_path);
   void createArgv(const std::string& script_path);
-  void createMetaVars(const HttpRequest& request, const std::string& path_info, const int cli_sock);
+  void createMetaVars(const HttpRequest& request, const HttpResponse& response, const int cli_sock);
   std::vector<std::string> split(const std::string& s, char delimiter) const;
   std::string searchCommandInPath(const std::string& command) const;
   bool isExecutableFile(const std::string& path) const;

--- a/src/server/HttpResponse.cpp
+++ b/src/server/HttpResponse.cpp
@@ -655,25 +655,23 @@ std::string HttpResponse::autoIndex(const std::string& directory_path, const std
 }
 
 HttpResponse::ResponsePhase HttpResponse::Index(HttpResponse& response, std::string& request_uri,
-                                                const std::vector<config::Index>& index_list,
-                                                bool is_alias, bool is_autoindex_on) {
+                                                const std::vector<config::Index>& index_list, bool is_alias,
+                                                bool is_autoindex_on) {
   std::string directory_path = (is_alias) ? response.root_path_ : response.root_path_ + request_uri;
 
   for (size_t i = 0; i < index_list.size(); i++) {
     std::string full_path = directory_path + index_list[i].getFile();
     if (isAccessible(full_path)) {
-      //response.res_file_path_ = full_path;
       response.res_file_path_ =
-        (is_alias) ? config::Index::kDefaultFile_ : request_uri + index_list[i].getFile();
+          (is_alias) ? config::Index::kDefaultFile_ : request_uri + index_list[i].getFile();
       return sw_content_phase;
     }
   }
   if (index_list.size() == 0) {
     std::string full_path = directory_path + config::Index::kDefaultFile_;
     if (isAccessible(full_path)) {
-      //response.res_file_path_ = full_path;
       response.res_file_path_ =
-        (is_alias) ? config::Index::kDefaultFile_ : request_uri + config::Index::kDefaultFile_;
+          (is_alias) ? config::Index::kDefaultFile_ : request_uri + config::Index::kDefaultFile_;
       return sw_content_phase;
     }
   }
@@ -709,7 +707,6 @@ HttpResponse::ResponsePhase HttpResponse::searchResPath(HttpResponse& response, 
       response.setStatusCode(404);
       return sw_error_page_phase;
     }
-    //response.res_file_path_ = full_path;
     response.res_file_path_ = request.uri;
     return sw_content_phase;
   }
@@ -727,8 +724,6 @@ HttpResponse::ResponsePhase HttpResponse::searchResPath(HttpResponse& response, 
     return TryFiles(response, request, location->try_files);
   else if (location && Utils::hasDirective(*location, kINDEX)) {
     if (Utils::hasDirective(*location, kALIAS)) is_alias = true;
-    //std::string directory_path =
-    //    (Utils::hasDirective(*location, kALIAS)) ? response.root_path_ : response.root_path_ + request.uri;
     return Index(response, request.uri, location->index_list, is_alias, is_autoindex_on);
   }
 
@@ -736,13 +731,11 @@ HttpResponse::ResponsePhase HttpResponse::searchResPath(HttpResponse& response, 
   if (Utils::hasDirective(server, kTRY_FILES))
     return TryFiles(response, request, server.try_files);
   else if (Utils::hasDirective(server, kINDEX))
-    return Index(response, request.uri, server.index_list, is_alias,
-                 is_autoindex_on);
+    return Index(response, request.uri, server.index_list, is_alias, is_autoindex_on);
 
   // http contextにindexディレクティブがあればその設定値をみるし、
   // なくとも、デフォルトのindexディレクティブを見る
-  return Index(response, request.uri, config_handler.config_->http.index_list,
-               is_alias, is_autoindex_on);
+  return Index(response, request.uri, config_handler.config_->http.index_list, is_alias, is_autoindex_on);
 }
 
 /**
@@ -862,8 +855,7 @@ bool HttpResponse::setPathinfoIfValidCgi(HttpResponse& response, HttpRequest& re
     if (i != 0) path += "/";
     path += segments[i];
 
-    if (cgi::CGIHandler::isCgi(response.root_path_ + path) &&
-        Utils::isFile(response.root_path_ + path)) {
+    if (cgi::CGIHandler::isCgi(response.root_path_ + path) && Utils::isFile(response.root_path_ + path)) {
       response.separatePathinfo(request.uri, path.size());
       request.uri = path;
       return true;

--- a/src/server/HttpResponse.hpp
+++ b/src/server/HttpResponse.hpp
@@ -94,7 +94,7 @@ class HttpResponse {
                                      const config::Server& server, const config::Location* location,
                                      const ConfigHandler& config_handler);
   static ResponsePhase Index(HttpResponse& response, std::string& request,
-                             const std::vector<config::Index>& index_list, std::string directory_path,
+                             const std::vector<config::Index>& index_list, bool is_alias,
                              bool is_autoindex_on);
   static ResponsePhase TryFiles(HttpResponse& response, HttpRequest& request,
                                 const config::TryFiles& try_files);

--- a/test/cgi/CGIExecutor_test.cpp
+++ b/test/cgi/CGIExecutor_test.cpp
@@ -39,7 +39,8 @@ HttpRequest initRequest(const config::REQUEST_METHOD method, const std::string& 
   return request;
 }
 
-HttpResponse initResponse(const std::string& root_path, const std::string& script_path, const std::string& path_info) {
+HttpResponse initResponse(const std::string& root_path, const std::string& script_path,
+                          const std::string& path_info) {
   HttpResponse response;
 
   response.root_path_ = root_path;
@@ -134,7 +135,8 @@ TEST(cgi_executor, document_response) {
 TEST(cgi_executor, local_redirect_res) {
   ConnectionData cd;
   cd.request =
-      test::initRequest(config::REQUEST_METHOD::GET, "test/cgi/cgi_files/executor/local_redirect_res.php", "HTTP/1.1", "", "", {{"Host", "tt"}});
+      test::initRequest(config::REQUEST_METHOD::GET, "test/cgi/cgi_files/executor/local_redirect_res.php",
+                        "HTTP/1.1", "", "", {{"Host", "tt"}});
   cd.response_ = test::initResponse("./", "/test/cgi/cgi_files/executor/local_redirect_res.php", "");
 
   const std::string expect = "Location: /\r\n\r\n";
@@ -190,7 +192,8 @@ TEST(cgi_executor, meta_vars) {
                              "<h2>QUERY_STRING=one=1&two=2&three=3</h2>"
                              // + "<h2>REMOTE_ADDR=127.0.0.1</h2>" テスト不可のため、別のテストを追加
                              // + "<h2>REMOTE_HOST=127.0.0.1</h2>" テスト不可のため、別のテストを追加
-                             + "<h2>REQUEST_METHOD=GET</h2>" + "<h2>SCRIPT_NAME=test/cgi/cgi_files/executor/meta_vars.py</h2>" +
+                             + "<h2>REQUEST_METHOD=GET</h2>" +
+                             "<h2>SCRIPT_NAME=test/cgi/cgi_files/executor/meta_vars.py</h2>" +
                              "<h2>SERVER_NAME=tt</h2>"
                              // + "<h2>SERVER_PORT=4242</h2>" テスト不可のため、別のテストを追加
                              + "<h2>SERVER_PROTOCOL=HTTP/1.1</h2>" + "<h2>SERVER_SOFTWARE=webserv/1.0</h2>";

--- a/test/cgi/CGIExecutor_test.cpp
+++ b/test/cgi/CGIExecutor_test.cpp
@@ -39,9 +39,10 @@ HttpRequest initRequest(const config::REQUEST_METHOD method, const std::string& 
   return request;
 }
 
-HttpResponse initResponse(const std::string& script_path, const std::string& path_info) {
+HttpResponse initResponse(const std::string& root_path, const std::string& script_path, const std::string& path_info) {
   HttpResponse response;
 
+  response.root_path_ = root_path;
   response.res_file_path_ = script_path;
   response.path_info_ = path_info;
 
@@ -123,7 +124,7 @@ TEST(cgi_executor, document_response) {
   ConnectionData cd;
   cd.request =
       test::initRequest(config::REQUEST_METHOD::GET, "/path/uri/", "HTTP/1.1", "", "", {{"Host", "tt"}});
-  cd.response_ = test::initResponse("test/cgi/cgi_files/executor/document_response.py", "");
+  cd.response_ = test::initResponse("./", "test/cgi/cgi_files/executor/document_response.py", "");
 
   const std::string expect_header = "content-type: text/html\r\nStatus: 200 OK\r\n\r\n";
   const std::string expect = !cd.request.body.empty() ? (expect_header + cd.request.body) : expect_header;
@@ -133,8 +134,8 @@ TEST(cgi_executor, document_response) {
 TEST(cgi_executor, local_redirect_res) {
   ConnectionData cd;
   cd.request =
-      test::initRequest(config::REQUEST_METHOD::GET, "/path/uri/", "HTTP/1.1", "", "", {{"Host", "tt"}});
-  cd.response_ = test::initResponse("test/cgi/cgi_files/executor/local_redirect_res.php", "");
+      test::initRequest(config::REQUEST_METHOD::GET, "test/cgi/cgi_files/executor/local_redirect_res.php", "HTTP/1.1", "", "", {{"Host", "tt"}});
+  cd.response_ = test::initResponse("./", "/test/cgi/cgi_files/executor/local_redirect_res.php", "");
 
   const std::string expect = "Location: /\r\n\r\n";
   test::testCgiOutput(cd, expect);
@@ -144,7 +145,7 @@ TEST(cgi_executor, client_redirect_res) {
   ConnectionData cd;
   cd.request =
       test::initRequest(config::REQUEST_METHOD::GET, "/path/uri/", "HTTP/1.1", "", "", {{"Host", "tt"}});
-  cd.response_ = test::initResponse("test/cgi/cgi_files/executor/client_redirect_res.cgi", "");
+  cd.response_ = test::initResponse("./", "test/cgi/cgi_files/executor/client_redirect_res.cgi", "");
 
   const std::string expect = "Location: https://www.google.com/\r\nMETHOD: GET\r\nSERVER_NAME: tachu\r\n\r\n";
   test::testCgiOutput(cd, expect);
@@ -154,7 +155,7 @@ TEST(cgi_executor, client_redirect_res_doc) {
   ConnectionData cd;
   cd.request =
       test::initRequest(config::REQUEST_METHOD::GET, "/path/uri/", "HTTP/1.1", "", "", {{"Host", "tt"}});
-  cd.response_ = test::initResponse("test/cgi/cgi_files/executor/client_redirect_res_doc.cgi", "");
+  cd.response_ = test::initResponse("./", "test/cgi/cgi_files/executor/client_redirect_res_doc.cgi", "");
 
   const std::string expect_header = "Location: /\r\nStatus: 301\r\nContent-Type: text/html\r\n\r\n";
   const std::string expect = expect_header + "<h1>cgi response</h1><h2>client-redirdoc-response<h2>\n";
@@ -166,7 +167,7 @@ TEST(cgi_executor, body) {
   cd.request = test::initRequest(config::REQUEST_METHOD::POST, "/path/uri/", "HTTP/1.1", "",
                                  "<h1>cgi response</h1><h2>body<h2><p>this is body message\ntesting</p>\n",
                                  {{"Host", "tt"}, {"Content-Length", "59"}});
-  cd.response_ = test::initResponse("test/cgi/cgi_files/executor/body.py", "");
+  cd.response_ = test::initResponse("./", "test/cgi/cgi_files/executor/body.py", "");
 
   const std::string expect_header = "Status: 200\r\nContent-Type: text/html\r\n\r\n";
   const std::string expect =
@@ -179,7 +180,7 @@ TEST(cgi_executor, meta_vars) {
   cd.request =
       test::initRequest(config::REQUEST_METHOD::GET, "/path/uri/", "HTTP/1.1", "one=1&two=2&three=3", "",
                         {{"Host", "tt"}, {"content-type", "text/html"}, {"CONTENT_LENGTH", "10"}});
-  cd.response_ = test::initResponse("test/cgi/cgi_files/executor/meta_vars.py", "/a/b/c/d//e");
+  cd.response_ = test::initResponse("./", "test/cgi/cgi_files/executor/meta_vars.py", "/a/b/c/d//e");
 
   const std::string expect_header = "content-type: text/html\r\nStatus: 200 OK\r\n\r\n";
   const std::string expect = expect_header + "<h1>env vars list</h1>" + "<h2>AUTH_TYPE=</h2>" +
@@ -189,7 +190,7 @@ TEST(cgi_executor, meta_vars) {
                              "<h2>QUERY_STRING=one=1&two=2&three=3</h2>"
                              // + "<h2>REMOTE_ADDR=127.0.0.1</h2>" テスト不可のため、別のテストを追加
                              // + "<h2>REMOTE_HOST=127.0.0.1</h2>" テスト不可のため、別のテストを追加
-                             + "<h2>REQUEST_METHOD=GET</h2>" + "<h2>SCRIPT_NAME=/path/uri/</h2>" +
+                             + "<h2>REQUEST_METHOD=GET</h2>" + "<h2>SCRIPT_NAME=test/cgi/cgi_files/executor/meta_vars.py</h2>" +
                              "<h2>SERVER_NAME=tt</h2>"
                              // + "<h2>SERVER_PORT=4242</h2>" テスト不可のため、別のテストを追加
                              + "<h2>SERVER_PROTOCOL=HTTP/1.1</h2>" + "<h2>SERVER_SOFTWARE=webserv/1.0</h2>";
@@ -200,7 +201,7 @@ TEST(cgi_executor, path_info_GET) {
   ConnectionData cd;
   cd.request = test::initRequest(config::REQUEST_METHOD::GET, "/path/uri/", "HTTP/1.1", "one=1&two=2&three=3",
                                  "", {{"Host", "tt"}, {"content-type", "text/html"}});
-  cd.response_ = test::initResponse("test/cgi/cgi_files/executor/path_info.py",
+  cd.response_ = test::initResponse("./", "test/cgi/cgi_files/executor/path_info.py",
                                     "/test/cgi/cgi_files/executor/path_info_dir/");
 
   const std::string expect_header = "Content-Type: text/html\r\nStatus: 200 OK\r\n\r\n";
@@ -215,7 +216,7 @@ TEST(cgi_executor, path_info_POST) {
   ConnectionData cd;
   cd.request = test::initRequest(config::REQUEST_METHOD::POST, "/path/uri/", "HTTP/1.1", "", "name=mahayase",
                                  {{"Host", "tt"}, {"content-type", "text/html"}, {"Content-Length", "13"}});
-  cd.response_ = test::initResponse("test/cgi/cgi_files/executor/post_and_pathinfo.py",
+  cd.response_ = test::initResponse("./", "test/cgi/cgi_files/executor/post_and_pathinfo.py",
                                     "/test/cgi/cgi_files/executor/path_info_dir/");
 
   const std::string expect_header = "Content-Type: text/html\r\nStatus: 200 OK\r\n\r\n";

--- a/test/server/HttpResponse/root/root_res_test.cpp
+++ b/test/server/HttpResponse/root/root_res_test.cpp
@@ -683,8 +683,7 @@ TEST(HttpResponseRoot, path_info1) {
                                         "/cgi-bin/path_info.php/path/info/", HttpRequest::PARSE_COMPLETE));
 
   // test member variables
-  test.testPathInfo(HttpResponse::RES_EXECUTE_CGI, "/cgi-bin/path_info.php",
-                    "/path/info/");
+  test.testPathInfo(HttpResponse::RES_EXECUTE_CGI, "/cgi-bin/path_info.php", "/path/info/");
 }
 
 TEST(HttpResponseRoot, path_info2) {
@@ -733,8 +732,7 @@ TEST(HttpResponseRoot, path_info4) {
                                         "/cgi-bin/path_info.php", HttpRequest::PARSE_COMPLETE));
 
   // test member variables
-  test.testPathInfo(HttpResponse::RES_EXECUTE_CGI, "/cgi-bin/path_info.php",
-                    "");
+  test.testPathInfo(HttpResponse::RES_EXECUTE_CGI, "/cgi-bin/path_info.php", "");
 }
 
 TEST(HttpResponseRoot, path_info5) {
@@ -746,8 +744,7 @@ TEST(HttpResponseRoot, path_info5) {
                                         "/cgi-bin/path_info.php/path1/path2/", HttpRequest::PARSE_COMPLETE));
 
   // test member variables
-  test.testPathInfo(HttpResponse::RES_EXECUTE_CGI, "/cgi-bin/path_info.php",
-                    "/path1/path2/");
+  test.testPathInfo(HttpResponse::RES_EXECUTE_CGI, "/cgi-bin/path_info.php", "/path1/path2/");
 }
 
 TEST(HttpResponseRoot, path_info6) {
@@ -759,8 +756,7 @@ TEST(HttpResponseRoot, path_info6) {
       "/cgi-bin/path_info.php/a/bc//d//ef/g/h/ij/k/lm/n", HttpRequest::PARSE_COMPLETE));
 
   // test member variables
-  test.testPathInfo(HttpResponse::RES_EXECUTE_CGI, "/cgi-bin/path_info.php",
-                    "/a/bc//d//ef/g/h/ij/k/lm/n");
+  test.testPathInfo(HttpResponse::RES_EXECUTE_CGI, "/cgi-bin/path_info.php", "/a/bc//d//ef/g/h/ij/k/lm/n");
 }
 
 TEST(HttpResponseRoot, path_info7) {

--- a/test/server/HttpResponse/root/root_res_test.cpp
+++ b/test/server/HttpResponse/root/root_res_test.cpp
@@ -683,7 +683,7 @@ TEST(HttpResponseRoot, path_info1) {
                                         "/cgi-bin/path_info.php/path/info/", HttpRequest::PARSE_COMPLETE));
 
   // test member variables
-  test.testPathInfo(HttpResponse::RES_EXECUTE_CGI, "test/server/HttpResponse/root/file/cgi-bin/path_info.php",
+  test.testPathInfo(HttpResponse::RES_EXECUTE_CGI, "/cgi-bin/path_info.php",
                     "/path/info/");
 }
 
@@ -733,7 +733,7 @@ TEST(HttpResponseRoot, path_info4) {
                                         "/cgi-bin/path_info.php", HttpRequest::PARSE_COMPLETE));
 
   // test member variables
-  test.testPathInfo(HttpResponse::RES_EXECUTE_CGI, "test/server/HttpResponse/root/file/cgi-bin/path_info.php",
+  test.testPathInfo(HttpResponse::RES_EXECUTE_CGI, "/cgi-bin/path_info.php",
                     "");
 }
 
@@ -746,7 +746,7 @@ TEST(HttpResponseRoot, path_info5) {
                                         "/cgi-bin/path_info.php/path1/path2/", HttpRequest::PARSE_COMPLETE));
 
   // test member variables
-  test.testPathInfo(HttpResponse::RES_EXECUTE_CGI, "test/server/HttpResponse/root/file/cgi-bin/path_info.php",
+  test.testPathInfo(HttpResponse::RES_EXECUTE_CGI, "/cgi-bin/path_info.php",
                     "/path1/path2/");
 }
 
@@ -759,7 +759,7 @@ TEST(HttpResponseRoot, path_info6) {
       "/cgi-bin/path_info.php/a/bc//d//ef/g/h/ij/k/lm/n", HttpRequest::PARSE_COMPLETE));
 
   // test member variables
-  test.testPathInfo(HttpResponse::RES_EXECUTE_CGI, "test/server/HttpResponse/root/file/cgi-bin/path_info.php",
+  test.testPathInfo(HttpResponse::RES_EXECUTE_CGI, "/cgi-bin/path_info.php",
                     "/a/bc//d//ef/g/h/ij/k/lm/n");
 }
 


### PR DESCRIPTION
### 対応内容
script_nameにroot_pathがくっついてしまっていたので、
HttpResponse::root_path_とHttpResponse::res_file_path_を明確に分け、足し合わせたときにfull_pathになるようにしました。

### 悩み
testについてなのですが、
gtestはすべて通り、test/run.pyも直接実行すれば通るのですが、make ptestで実行すると失敗するテストが増えてしまいます。
原因は調査中です。