### PR TITLE
Issue219 crash stress test

### DIFF
--- a/src/server/CGIHandler.cpp
+++ b/src/server/CGIHandler.cpp
@@ -41,7 +41,11 @@ bool cgi::CGIHandler::isCgi(const std::string& script_path) {
  */
 bool cgi::CGIHandler::forkCgiProcess(const HttpRequest& request, const HttpResponse& response) {
   pid_t pid = SysCallWrapper::Fork();
-  if (pid == -1) return false;
+  if (pid == -1) {
+    close(this->sockets_[SOCKET_PARENT]);
+    close(this->sockets_[SOCKET_CHILD]);
+    return false;
+  }
   if (pid == 0) {
     close(this->sockets_[SOCKET_PARENT]);
     this->cgi_executor_.executeCgiScript(request, response, this->sockets_[SOCKET_CHILD], this->cli_socket_);

--- a/src/server/ConnectionManager.cpp
+++ b/src/server/ConnectionManager.cpp
@@ -1,15 +1,3 @@
-/* ************************************************************************** */
-/*                                                                            */
-/*                                                        :::      ::::::::   */
-/*   ConnectionManager.cpp                              :+:      :+:    :+:   */
-/*                                                    +:+ +:+         +:+     */
-/*   By: 0 <0>                                      +#+  +:+       +#+        */
-/*                                                +#+#+#+#+#+   +#+           */
-/*   Created: 2024/06/17 19:32:30 by 0                 #+#    #+#             */
-/*   Updated: 2024/06/17 19:34:55 by 0                ###   ########.fr       */
-/*                                                                            */
-/* ************************************************************************** */
-
 #include "ConnectionManager.hpp"
 
 #include <unistd.h>
@@ -201,7 +189,6 @@ void ConnectionManager::closeAllConnections() {
     close(it->first);
     delete it->second;
   }
-  this->connections_.clear();
 }
 
 connection_size ConnectionManager::getCgiSockNum() const { return cgi_sock_num_; }

--- a/src/server/ConnectionManager.cpp
+++ b/src/server/ConnectionManager.cpp
@@ -1,3 +1,15 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   ConnectionManager.cpp                              :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: 0 <0>                                      +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2024/06/17 19:32:30 by 0                 #+#    #+#             */
+/*   Updated: 2024/06/17 19:34:55 by 0                ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
 #include "ConnectionManager.hpp"
 
 #include <unistd.h>
@@ -175,6 +187,15 @@ bool ConnectionManager::isCgiSocket(const int fd) const {
 }
 
 void ConnectionManager::closeAllConnections() {
+  for (std::map<int, ConnectionData*>::iterator it = this->connections_.begin();
+       it != this->connections_.end();) {
+    std::map<int, ConnectionData*>::iterator tmp = it;
+    ++it;
+    if (isCgiSocket(tmp->first)) {
+      close(tmp->first);
+      connections_.erase(tmp->first);
+    }
+  }
   for (std::map<int, ConnectionData*>::iterator it = this->connections_.begin();
        it != this->connections_.end(); ++it) {
     close(it->first);

--- a/src/server/EpollServer.cpp
+++ b/src/server/EpollServer.cpp
@@ -49,7 +49,7 @@ bool EpollServer::initEpollEvent(const std::map<int, ConnectionData*>& connectio
   for (std::map<int, ConnectionData*>::const_iterator it = connections.begin(); it != connections.end();
        ++it) {
     struct epoll_event ep;
-    memset(&ep, 0, sizeof(ep));
+    std::memset(&ep, 0, sizeof(ep));
     ep.events = it->second->event == ConnectionData::EV_READ ? EPOLLIN : EPOLLOUT;
     ep.data.fd = it->first;
 
@@ -184,7 +184,7 @@ int EpollServer::waitForEvent(ConnectionManager* conn_manager, IActiveEventManag
 
 int EpollServer::addNewEvent(const int fd, const uint32_t event_filter) {
   struct epoll_event new_event;
-  memset(&new_event, 0, sizeof(new_event));
+  std::memset(&new_event, 0, sizeof(new_event));
   new_event.events = event_filter;
   new_event.data.fd = fd;
   int re = epoll_ctl(this->epfd_, EPOLL_CTL_ADD, new_event.data.fd, &new_event);

--- a/src/server/EpollServer.cpp
+++ b/src/server/EpollServer.cpp
@@ -49,6 +49,7 @@ bool EpollServer::initEpollEvent(const std::map<int, ConnectionData*>& connectio
   for (std::map<int, ConnectionData*>::const_iterator it = connections.begin(); it != connections.end();
        ++it) {
     struct epoll_event ep;
+    memset(&ep, 0, sizeof(ep));
     ep.events = it->second->event == ConnectionData::EV_READ ? EPOLLIN : EPOLLOUT;
     ep.data.fd = it->first;
 
@@ -140,10 +141,6 @@ void EpollServer::callEventHandler(ConnectionManager* conn_manager, IActiveEvent
         break;
 
       case RequestHandler::UPDATE_CGI_READ:
-        if (is_cgi_sock) {
-          updateEvent(active_events[i], EPOLLIN);
-          break;
-        }
         deleteEvent(active_events[i]);  // client socketを監視から一時的に削除する
         addNewEvent(cgi_handler.getCgiSocket(), EPOLLIN);
         break;
@@ -187,6 +184,7 @@ int EpollServer::waitForEvent(ConnectionManager* conn_manager, IActiveEventManag
 
 int EpollServer::addNewEvent(const int fd, const uint32_t event_filter) {
   struct epoll_event new_event;
+  memset(&new_event, 0, sizeof(new_event));
   new_event.events = event_filter;
   new_event.data.fd = fd;
   int re = epoll_ctl(this->epfd_, EPOLL_CTL_ADD, new_event.data.fd, &new_event);

--- a/src/server/NetworkIOHandler.cpp
+++ b/src/server/NetworkIOHandler.cpp
@@ -145,12 +145,8 @@ int NetworkIOHandler::acceptConnection(ConnectionManager& connManager, const int
 }
 
 bool NetworkIOHandler::isListenSocket(const int listen_fd) const {
-  try {
-    this->listenfd_map_.at(listen_fd);
-    return true;
-  } catch (const std::out_of_range& e) {
-    return false;
-  }
+  if (this->listenfd_map_.find(listen_fd) == this->listenfd_map_.end()) return false;
+  return true;
 }
 
 /**

--- a/src/server/NetworkIOHandler.cpp
+++ b/src/server/NetworkIOHandler.cpp
@@ -145,8 +145,7 @@ int NetworkIOHandler::acceptConnection(ConnectionManager& connManager, const int
 }
 
 bool NetworkIOHandler::isListenSocket(const int listen_fd) const {
-  if (this->listenfd_map_.find(listen_fd) == this->listenfd_map_.end()) return false;
-  return true;
+  return this->listenfd_map_.find(listen_fd) != this->listenfd_map_.end();
 }
 
 /**


### PR DESCRIPTION
WebServerのデストラクタが呼ばれた時のダブルフリーなどが起きないよう修正しました。
epollに関する修正はこちらのブランチでは行わないことになりました。