### PR TITLE
Issue268 return timeout response

### DIFF
--- a/conf/webserv.conf
+++ b/conf/webserv.conf
@@ -15,7 +15,7 @@ http {
     listen 127.0.0.1:4242 default_server;
     listen 127.0.0.1:8005;
     server_name localhost;
-    index /index.html;
+    index index.html;
 
     location / {
       root html;

--- a/src/cgi/CgiHandler.cpp
+++ b/src/cgi/CgiHandler.cpp
@@ -114,7 +114,7 @@ void cgi::CgiHandler::resetSockets() {
  * @return true cgi processが死んでいる
  * @return false cgi processがまだ生きている
  */
-bool cgi::CgiHandler::cgiProcessExited(const pid_t process_id, int* status) {
+bool cgi::CgiHandler::cgiProcessExited(pid_t process_id, int* status) {
   pid_t re = waitpid(process_id, status, WNOHANG);
   // errorまたはprocessが終了していない
   // errorのときの処理はあやしい, -1のエラーはロジック的にありえない(process idがおかしい)

--- a/src/cgi/CgiHandler.cpp
+++ b/src/cgi/CgiHandler.cpp
@@ -93,7 +93,7 @@ int cgi::CgiHandler::getCgiSocket() const { return this->sockets_[SOCKET_PARENT]
  *
  */
 void cgi::CgiHandler::killCgiProcess() const {
-  if (kill(this->cgi_process_id_, SIGINT) == -1)
+  if (kill(this->cgi_process_id_, SIGTERM) == -1)
     WebServer::writeErrorlog(error::strSysCallError("kill"), config::EMERG);
 }
 

--- a/src/cgi/CgiHandler.cpp
+++ b/src/cgi/CgiHandler.cpp
@@ -93,7 +93,7 @@ int cgi::CgiHandler::getCgiSocket() const { return this->sockets_[SOCKET_PARENT]
  *
  */
 void cgi::CgiHandler::killCgiProcess() const {
-  if (kill(this->cgi_process_id_, SIGTERM) == -1)
+  if (kill(this->cgi_process_id_, SIGKILL) == -1)
     WebServer::writeErrorlog(error::strSysCallError("kill"), config::EMERG);
 }
 

--- a/src/cgi/CgiHandler.cpp
+++ b/src/cgi/CgiHandler.cpp
@@ -116,8 +116,6 @@ void cgi::CgiHandler::resetSockets() {
  */
 bool cgi::CgiHandler::cgiProcessExited(pid_t process_id, int* status) {
   pid_t re = waitpid(process_id, status, WNOHANG);
-  // errorまたはprocessが終了していない
-  // errorのときの処理はあやしい, -1のエラーはロジック的にありえない(process idがおかしい)
   if (re == 0) return false;
   // errorの時も子プロセスが存在しないと判断する
   return true;

--- a/src/cgi/CgiHandler.cpp
+++ b/src/cgi/CgiHandler.cpp
@@ -3,6 +3,7 @@
 #include <signal.h>
 #include <stdio.h>
 #include <sys/socket.h>
+#include <sys/wait.h>
 
 #include <cstdlib>
 #include <cstring>
@@ -104,4 +105,20 @@ void cgi::CgiHandler::killCgiProcess() const {
 void cgi::CgiHandler::resetSockets() {
   this->sockets_[0] = -1;
   this->sockets_[1] = -1;
+}
+
+/**
+ * @brief cgi processが生きているか確認。死んでいたらstatusでexit status確認。
+ *
+ * @param process_id, status
+ * @return true cgi processが死んでいる
+ * @return false cgi processがまだ生きている
+ */
+bool cgi::CgiHandler::cgiProcessExited(const pid_t process_id, int* status) {
+  pid_t re = waitpid(process_id, status, WNOHANG);
+  // errorまたはprocessが終了していない
+  // errorのときの処理はあやしい, -1のエラーはロジック的にありえない(process idがおかしい)
+  if (re == 0) return false;
+  // errorの時も子プロセスが存在しないと判断する
+  return true;
 }

--- a/src/cgi/CgiHandler.hpp
+++ b/src/cgi/CgiHandler.hpp
@@ -32,7 +32,7 @@ class CgiHandler {
   CgiHandler();
   ~CgiHandler();
   static bool isCgi(const std::string& script_path);
-  static bool cgiProcessExited(const pid_t process_id, int* status);
+  static bool cgiProcessExited(pid_t process_id, int* status);
   bool callCgiExecutor(const HttpResponse& response, const HttpRequest& request, int cli_sock);
   bool callCgiParser(HttpResponse& response, const std::string& cgi_response);
   void killCgiProcess() const;

--- a/src/cgi/CgiHandler.hpp
+++ b/src/cgi/CgiHandler.hpp
@@ -32,6 +32,7 @@ class CgiHandler {
   CgiHandler();
   ~CgiHandler();
   static bool isCgi(const std::string& script_path);
+  static bool cgiProcessExited(const pid_t process_id, int* status);
   bool callCgiExecutor(const HttpResponse& response, const HttpRequest& request, int cli_sock);
   bool callCgiParser(HttpResponse& response, const std::string& cgi_response);
   void killCgiProcess() const;

--- a/src/http/HttpResponse.cpp
+++ b/src/http/HttpResponse.cpp
@@ -466,7 +466,7 @@ HttpResponse::ResponsePhase HttpResponse::handlePreSearchLocationPhase(HttpReque
                                                                        struct sockaddr_in& client_addr) {
   switch (response.state_) {
     case RES_COMPLETE:
-      clear(response);
+      response.clear();
       break;
     case RES_PARSED_CGI:
       return sw_end_phase;
@@ -922,14 +922,14 @@ void HttpResponse::separatePathinfo(const std::string& uri, size_t pos) {
   this->path_info_ = uri.substr(pos);
 }
 
-void HttpResponse::clear(HttpResponse& response) {
-  response.root_path_.clear();
-  response.res_file_path_.clear();
-  response.path_info_.clear();
-  response.state_ = RES_CREATING_STATIC;
-  response.status_code_line_.clear();
-  response.status_code_ = kInitStatusCode;
-  response.headers_.clear();
-  response.body_.clear();
-  response.internal_redirect_cnt_ = 0;
+void HttpResponse::clear() {
+  this->root_path_.clear();
+  this->res_file_path_.clear();
+  this->path_info_.clear();
+  this->state_ = RES_CREATING_STATIC;
+  this->status_code_line_.clear();
+  this->status_code_ = kInitStatusCode;
+  this->headers_.clear();
+  this->body_.clear();
+  this->internal_redirect_cnt_ = 0;
 }

--- a/src/http/HttpResponse.hpp
+++ b/src/http/HttpResponse.hpp
@@ -45,7 +45,7 @@ class HttpResponse {
   static bool isKeepaliveConnection(const HttpResponse& response);
   static bool isErrorResponse(const HttpResponse& response);
   static void setup();
-  static void clear(HttpResponse& response);
+  void clear();
 
   std::string root_path_;
   std::string res_file_path_;

--- a/src/http/HttpResponse.hpp
+++ b/src/http/HttpResponse.hpp
@@ -45,6 +45,7 @@ class HttpResponse {
   static bool isKeepaliveConnection(const HttpResponse& response);
   static bool isErrorResponse(const HttpResponse& response);
   static void setup();
+  static void clear(HttpResponse& response);
 
   std::string root_path_;
   std::string res_file_path_;
@@ -103,7 +104,6 @@ class HttpResponse {
   static bool isExecutable(const std::string& file_path);
   static bool setPathinfoIfValidCgi(HttpResponse& response, HttpRequest& request);
   void separatePathinfo(const std::string& uri, size_t pos);
-  static void clear(HttpResponse& response);
 
   size_t internal_redirect_cnt_;
   static const size_t kMaxInternalRedirect = 10;

--- a/src/server/ConnectionManager.cpp
+++ b/src/server/ConnectionManager.cpp
@@ -1,7 +1,7 @@
 #include "ConnectionManager.hpp"
 
-#include <unistd.h>
 #include <sys/wait.h>
+#include <unistd.h>
 
 #include <algorithm>
 

--- a/src/server/ConnectionManager.cpp
+++ b/src/server/ConnectionManager.cpp
@@ -219,15 +219,15 @@ connection_size ConnectionManager::getCgiSockNum() const { return cgi_sock_num_;
 void ConnectionManager::addKilledPid(pid_t pid) { this->killed_pids_.push_back(pid); }
 
 /**
- * cgi processをkillした際にaddKilledPidで追加したpidをwaitする
- * waitpidに成功したpidはリストから削除する。
- * waitpidに失敗したpidはリストに残し、また次の機会にwaitpidする
+ * @brief killしたcgi processがゾンビプロセスになっているので、waitpidして回収する。
+ *        waitpidに成功したpidはリストから削除する。
+ *        waitpidに失敗したpidはリストに残し、また次の呼び出し時にwaitpidする
  */
 void ConnectionManager::waitKilledProcesses() {
   for (std::list<pid_t>::iterator it = this->killed_pids_.begin(); it != this->killed_pids_.end();) {
     std::list<pid_t>::iterator next = it;
     ++next;
-    if (cgi::CgiHandler::cgiProcessExited(*it, NULL)) {
+    if (waitpid(process_id, NULL, WNOHANG) != 0) {
       this->killed_pids_.erase(it);
       break;
     }

--- a/src/server/ConnectionManager.cpp
+++ b/src/server/ConnectionManager.cpp
@@ -1,6 +1,7 @@
 #include "ConnectionManager.hpp"
 
 #include <unistd.h>
+#include <sys/wait.h>
 
 #include <algorithm>
 
@@ -227,7 +228,7 @@ void ConnectionManager::waitKilledProcesses() {
   for (std::list<pid_t>::iterator it = this->killed_pids_.begin(); it != this->killed_pids_.end();) {
     std::list<pid_t>::iterator next = it;
     ++next;
-    if (waitpid(process_id, NULL, WNOHANG) != 0) {
+    if (waitpid(*it, NULL, WNOHANG) != 0) {
       this->killed_pids_.erase(it);
       break;
     }

--- a/src/server/ConnectionManager.cpp
+++ b/src/server/ConnectionManager.cpp
@@ -173,6 +173,7 @@ void ConnectionManager::clearResData(int fd) {
   cd->cgi_response_.clear();
   resetCgiSockets(fd);
   resetSentBytes(fd);
+  cd->response_.clear();
 }
 
 void ConnectionManager::clearConnectionData(int fd) {

--- a/src/server/ConnectionManager.cpp
+++ b/src/server/ConnectionManager.cpp
@@ -226,8 +226,7 @@ void ConnectionManager::waitKilledProcesses() {
   for (std::list<pid_t>::iterator it = this->killed_pids_.begin(); it != this->killed_pids_.end();) {
     std::list<pid_t>::iterator next = it;
     ++next;
-    int status = 0;
-    if (EventHandler::cgiProcessExited(*it, status)) {
+    if (cgi::CgiHandler::cgiProcessExited(*it, NULL)) {
       this->killed_pids_.erase(it);
       break;
     }

--- a/src/server/ConnectionManager.cpp
+++ b/src/server/ConnectionManager.cpp
@@ -230,7 +230,6 @@ void ConnectionManager::waitKilledProcesses() {
     ++next;
     if (waitpid(*it, NULL, WNOHANG) != 0) {
       this->killed_pids_.erase(it);
-      break;
     }
     it = next;
   }

--- a/src/server/ConnectionManager.hpp
+++ b/src/server/ConnectionManager.hpp
@@ -1,6 +1,7 @@
 #ifndef CONNECTION_MANAGER_HPP
 #define CONNECTION_MANAGER_HPP
 
+#include <list>
 #include <map>
 #include <vector>
 
@@ -80,6 +81,8 @@ class ConnectionManager {
   bool isClosedConnection(int fd) const;
   void clearClosedConnections();
   connection_size getCgiSockNum() const;
+  void addKilledPid(pid_t pid);
+  void waitKilledProcesses();
 
  private:
   ConnectionManager(const ConnectionManager&);
@@ -88,6 +91,7 @@ class ConnectionManager {
   std::map<int, ConnectionData*> connections_;
   std::set<int> closed_connections_;  // event handlerによって、接続を切られたfdを管理する
                                       // 発生したイベントのハンドラーが全て呼ばれたら毎回リセットされる
+  std::list<pid_t> killed_pids_;
   connection_size cgi_sock_num_;
 };
 

--- a/src/server/EpollServer.cpp
+++ b/src/server/EpollServer.cpp
@@ -24,6 +24,9 @@ void EpollServer::eventLoop(ConnectionManager* conn_manager, IActiveEventManager
     // 発生したイベントをhandle
     callEventHandler(conn_manager, event_manager, io_handler, timer_tree);
 
+    // killしたprocessを回収する
+    conn_manager->waitKilledProcesses();
+
     // 発生したすべてのイベントを削除
     event_manager->clearAllEvents();
   }

--- a/src/server/EventHandler.cpp
+++ b/src/server/EventHandler.cpp
@@ -291,7 +291,7 @@ void EventHandler::handleTimeoutEvent(NetworkIOHandler &io_handler, ConnectionMa
       // timeoutしたcgiの処理
       const cgi::CgiHandler &cgi_handler = conn_manager.getCgiHandler(cgi_sock);
       cgi_handler.killCgiProcess();
-      killed_pids.push_back(cgi_handler.getCgiProcessId()); // kill したcgiのpidを保存
+      killed_pids.push_back(cgi_handler.getCgiProcessId());  // kill したcgiのpidを保存
       io_handler.closeConnection(conn_manager, server, timer_tree, cgi_sock);
       config_handler.writeErrorLog("cgi timed out", config::DEBUG);  // debug
       it = next;
@@ -305,17 +305,15 @@ void EventHandler::handleTimeoutEvent(NetworkIOHandler &io_handler, ConnectionMa
   waitKilledProcess(killed_pids);
 }
 
-void  EventHandler::waitKilledProcess(std::vector<pid_t>& killed_pids) const {
-  for (size_t i = 0;i < killed_pids.size(); i++) {
+void EventHandler::waitKilledProcess(std::vector<pid_t> &killed_pids) const {
+  for (size_t i = 0; i < killed_pids.size(); i++) {
     int status = 0;
     while (true) {
-      if (cgiProcessExited(killed_pids[i], status))
-        break;
-      std::cout << "didnot wait cgi process.\n"; // cgi processが生きている
+      if (cgiProcessExited(killed_pids[i], status)) break;
+      std::cout << "didnot wait cgi process.\n";  // cgi processが生きている
     }
   }
 }
-
 
 /**
  * @brief cgi processが生きているか確認。死んでいたらstatusでexit status確認。

--- a/src/server/EventHandler.cpp
+++ b/src/server/EventHandler.cpp
@@ -299,7 +299,6 @@ void EventHandler::handleTimeoutEvent(NetworkIOHandler &io_handler, ConnectionMa
       // 504 error responseを生成
       HttpResponse &response = conn_manager.getResponse(cli_sock);
       conn_manager.clearResData(cli_sock);
-      HttpResponse::clear(response);
       response.state_ = HttpResponse::RES_CGI_TIMEOUT;
       handleResponse(io_handler, conn_manager, config_handler, server, timer_tree, cli_sock);  // 中でsetEvent
       server->addNewEvent(

--- a/src/server/EventHandler.cpp
+++ b/src/server/EventHandler.cpp
@@ -104,8 +104,8 @@ void EventHandler::handleResponse(NetworkIOHandler &io_handler, ConnectionManage
   int client = conn_manager.isCgiSocket(sock) ? conn_manager.getCgiHandler(sock).getCliSocket() : sock;
   addTimerByType(conn_manager, config_handler, timer_tree, client, Timer::TMO_KEEPALIVE);
 
-  // cgi socketの場合は、クライアントをイベントとして登録する
-  if (conn_manager.isCgiSocket(sock) || conn_manager.getEvent(sock) == ConnectionData::EV_CGI_READ ||
+  // cgiのイベントを処理している場合は、clientをイベントとして登録する
+  if (conn_manager.getEvent(sock) == ConnectionData::EV_CGI_READ ||
       conn_manager.getEvent(sock) == ConnectionData::EV_CGI_WRITE)
     server->addNewEvent(client, ConnectionData::EV_WRITE);
   else
@@ -276,7 +276,6 @@ void EventHandler::handleErrorEvent(NetworkIOHandler &io_handler, ConnectionMana
 void EventHandler::handleTimeoutEvent(NetworkIOHandler &io_handler, ConnectionManager &conn_manager,
                                       IServer *server, TimerTree &timer_tree) const {
   const ConfigHandler &config_handler = WebServer::getConfigHandler();
-  std::vector<pid_t> killed_pids;
   // timeoutしていない最初のイテレータを取得
   Timer current_time(-1, 0);
   std::multiset<Timer>::iterator upper_bound = timer_tree.getTimerTree().upper_bound(current_time);

--- a/src/server/EventHandler.cpp
+++ b/src/server/EventHandler.cpp
@@ -291,7 +291,6 @@ void EventHandler::handleTimeoutEvent(NetworkIOHandler &io_handler, ConnectionMa
       const cgi::CgiHandler &cgi_handler = conn_manager.getCgiHandler(cgi_sock);
       cgi_handler.killCgiProcess();
       io_handler.closeConnection(conn_manager, server, timer_tree, cgi_sock);
-      conn_manager.clearResData(cgi_handler.getCliSocket());
       config_handler.writeErrorLog("cgi timed out", config::DEBUG);  // debug
       it = next;
       continue;

--- a/src/server/EventHandler.cpp
+++ b/src/server/EventHandler.cpp
@@ -300,10 +300,10 @@ void EventHandler::handleTimeoutEvent(NetworkIOHandler &io_handler, ConnectionMa
       HttpResponse &response = conn_manager.getResponse(cli_sock);
       conn_manager.clearResData(cli_sock);
       response.state_ = HttpResponse::RES_CGI_TIMEOUT;
-      handleResponse(io_handler, conn_manager, config_handler, server, timer_tree, cli_sock);  // 中でsetEvent
       server->addNewEvent(
           cli_sock, ConnectionData::
-                        EV_WRITE);  // handleResponse()ではupdateしているだけなので、ちゃんとaddNewEventを呼ぶ
+                        EV_WRITE);  // handleResponse()ではupdateEvent()が呼ばれるので、先にaddNewEventを呼ぶ
+      handleResponse(io_handler, conn_manager, config_handler, server, timer_tree, cli_sock);  // 中でsetEvent
       it = next;
       continue;
     }

--- a/src/server/EventHandler.hpp
+++ b/src/server/EventHandler.hpp
@@ -40,7 +40,7 @@ class EventHandler {
   void addTimerByType(ConnectionManager &conn_manager, const ConfigHandler &config_handler,
                       TimerTree &timer_tree, int sock, enum Timer::TimeoutType type) const;
   bool isOverWorkerConnections(ConnectionManager &conn_manager, const ConfigHandler &config_handler) const;
-  void  waitKilledProcess(std::vector<pid_t>& killed_pids) const;
+  void waitKilledProcess(std::vector<pid_t> &killed_pids) const;
 };
 
 #endif

--- a/src/server/EventHandler.hpp
+++ b/src/server/EventHandler.hpp
@@ -24,11 +24,11 @@ class EventHandler {
                         TimerTree &timer_tree, int sock) const;
   void handleTimeoutEvent(NetworkIOHandler &io_handler, ConnectionManager &conn_manager, IServer *server,
                           TimerTree &timer_tree) const;
+  static bool cgiProcessExited(pid_t process_id, int &status);
 
  private:
   EventHandler(const EventHandler &);
   EventHandler &operator=(const EventHandler &);
-  bool cgiProcessExited(pid_t process_id, int &status) const;
   void handleRequest(NetworkIOHandler &io_handler, ConnectionManager &conn_manager,
                      const ConfigHandler &config_handler, IServer *server, TimerTree &timer_tree,
                      int sock) const;

--- a/src/server/EventHandler.hpp
+++ b/src/server/EventHandler.hpp
@@ -24,7 +24,6 @@ class EventHandler {
                         TimerTree &timer_tree, int sock) const;
   void handleTimeoutEvent(NetworkIOHandler &io_handler, ConnectionManager &conn_manager, IServer *server,
                           TimerTree &timer_tree) const;
-  static bool cgiProcessExited(pid_t process_id, int &status);
 
  private:
   EventHandler(const EventHandler &);

--- a/src/server/EventHandler.hpp
+++ b/src/server/EventHandler.hpp
@@ -40,6 +40,7 @@ class EventHandler {
   void addTimerByType(ConnectionManager &conn_manager, const ConfigHandler &config_handler,
                       TimerTree &timer_tree, int sock, enum Timer::TimeoutType type) const;
   bool isOverWorkerConnections(ConnectionManager &conn_manager, const ConfigHandler &config_handler) const;
+  void  waitKilledProcess(std::vector<pid_t>& killed_pids) const;
 };
 
 #endif

--- a/src/server/KqueueServer.cpp
+++ b/src/server/KqueueServer.cpp
@@ -20,6 +20,9 @@ void KqueueServer::eventLoop(ConnectionManager* conn_manager, IActiveEventManage
     // 発生したイベントをhandleする
     callEventHandler(conn_manager, event_manager, io_handler, timer_tree);
 
+    // killしたprocessを回収する
+    conn_manager->waitKilledProcesses();
+
     // 発生したすべてのイベントを削除
     event_manager->clearAllEvents();
   }

--- a/src/server/PollServer.cpp
+++ b/src/server/PollServer.cpp
@@ -15,6 +15,9 @@ void PollServer::eventLoop(ConnectionManager* conn_manager, IActiveEventManager*
     // 発生したイベントをhandleする
     callEventHandler(conn_manager, event_manager, io_handler, timer_tree);
 
+    // killしたprocessを回収する
+    conn_manager->waitKilledProcesses();
+
     // 発生したすべてのイベントを削除
     event_manager->clearAllEvents();
   }
@@ -41,6 +44,7 @@ int PollServer::waitForEvent(NetworkIOHandler* io_handler, ConnectionManager* co
     if (conn_manager->isCgiSocket(timeout_fd)) {
       const cgi::CgiHandler& cgi_handler = conn_manager->getCgiHandler(timeout_fd);
       cgi_handler.killCgiProcess();
+      conn_manager->addKilledPid(cgi_handler.getCgiProcessId());  // kill したcgiのpidを保存
     }
     io_handler->purgeConnection(*conn_manager, this, *timer_tree, timeout_fd);
   }

--- a/src/server/SelectServer.cpp
+++ b/src/server/SelectServer.cpp
@@ -16,6 +16,9 @@ void SelectServer::eventLoop(ConnectionManager* conn_manager, IActiveEventManage
 
     callEventHandler(conn_manager, event_manager, io_handler, timer_tree);
 
+    // killしたprocessを回収する
+    conn_manager->waitKilledProcesses();
+
     event_manager->clearAllEvents();
   }
 }
@@ -42,6 +45,7 @@ int SelectServer::waitForEvent(NetworkIOHandler* io_handler, ConnectionManager* 
     if (conn_manager->isCgiSocket(timeout_fd)) {
       const cgi::CgiHandler& cgi_handler = conn_manager->getCgiHandler(timeout_fd);
       cgi_handler.killCgiProcess();
+      conn_manager->addKilledPid(cgi_handler.getCgiProcessId());  // kill したcgiのpidを保存
     }
     io_handler->purgeConnection(*conn_manager, this, *timer_tree, timeout_fd);
   }

--- a/test/integration_test/server_res_test.sh
+++ b/test/integration_test/server_res_test.sh
@@ -102,7 +102,7 @@ function runTest {
   assert "${root}/dynamic/client_redirect_res_doc.cgi" "302" "GET" ""
   assert "${root}/dynamic/body_res.py" "200" "GET" ""
   assert "${root}/dynamic/post_cgi.py?key=value" "200" "GET" ""
-  assert "${root}/dynamic/timeout.cgi" "504" "GET" ""
+  assert "${root}/dynamic/timeout.py" "504" "GET" ""
   # HEAD
   assert "${root}/static/index.html" "200" "HEAD" ""
   assert "${root}/static/nonexist" "404" "HEAD" ""
@@ -115,7 +115,7 @@ function runTest {
   assert "${root}/dynamic/client_redirect_res_doc.cgi" "302" "GET" ""
   assert "${root}/dynamic/body_res.py" "200" "GET" ""
   assert "${root}/dynamic/post_cgi.py?key=value" "200" "GET" ""
-  assert "${root}/dynamic/timeout.cgi" "504" "GET" ""
+  assert "${root}/dynamic/timeout.py" "504" "GET" ""
 
   # POST
   assert "${root}/dynamic/post_cgi.py" "200" "POST" "-d key=value"
@@ -129,7 +129,7 @@ function runTest {
   assert "${root}/dynamic/client_redirect_res.cgi" "302" "POST" ""
   assert "${root}/dynamic/client_redirect_res_doc.cgi" "302" "POST" ""
   assert "${root}/dynamic/body_res.py" "200" "POST" ""
-  assert "${root}/dynamic/timeout.cgi" "504" "GET" ""
+  assert "${root}/dynamic/timeout.py" "504" "GET" ""
 
   # DELETE
   assert "${root}/dynamic/post_cgi.py" "405" "DELETE" ""
@@ -141,7 +141,7 @@ function runTest {
   assert "${root}/dynamic/client_redirect_res.cgi" "302" "DELETE" ""
   assert "${root}/dynamic/client_redirect_res_doc.cgi" "302" "DELETE" ""
   assert "${root}/dynamic/body_res.py" "200" "DELETE" ""
-  assert "${root}/dynamic/timeout.cgi" "504" "GET" ""
+  assert "${root}/dynamic/timeout.py" "504" "GET" ""
 
   # サーバープロセスを終了
   kill ${webserv_pid} >/dev/null 2>&1

--- a/test/integration_test/server_res_test.sh
+++ b/test/integration_test/server_res_test.sh
@@ -65,8 +65,8 @@ function assert {
   local option=$4
   printf "[  test${g_test_index}  ]\n${request} ${method}: "
 
-  # responseのtimeoutを1秒に設定 --max-time
-  local actual=$(curl -X ${method} ${option} -s -o /dev/null -w "%{http_code}" ${request} --max-time 1.5)
+  # responseのtimeoutを3秒に設定 --max-time
+  local actual=$(curl -X ${method} ${option} -s -o /dev/null -w "%{http_code}" ${request} --max-time 3)
   local expect=$2
   if [ "${actual}" == "${expect}" ]; then
     printf "${GREEN}passed${WHITE}\n\n"
@@ -102,6 +102,7 @@ function runTest {
   assert "${root}/dynamic/client_redirect_res_doc.cgi" "302" "GET" ""
   assert "${root}/dynamic/body_res.py" "200" "GET" ""
   assert "${root}/dynamic/post_cgi.py?key=value" "200" "GET" ""
+  assert "${root}/dynamic/timeout.cgi" "504" "GET" ""
   # HEAD
   assert "${root}/static/index.html" "200" "HEAD" ""
   assert "${root}/static/nonexist" "404" "HEAD" ""
@@ -114,6 +115,7 @@ function runTest {
   assert "${root}/dynamic/client_redirect_res_doc.cgi" "302" "GET" ""
   assert "${root}/dynamic/body_res.py" "200" "GET" ""
   assert "${root}/dynamic/post_cgi.py?key=value" "200" "GET" ""
+  assert "${root}/dynamic/timeout.cgi" "504" "GET" ""
 
   # POST
   assert "${root}/dynamic/post_cgi.py" "200" "POST" "-d key=value"
@@ -127,6 +129,7 @@ function runTest {
   assert "${root}/dynamic/client_redirect_res.cgi" "302" "POST" ""
   assert "${root}/dynamic/client_redirect_res_doc.cgi" "302" "POST" ""
   assert "${root}/dynamic/body_res.py" "200" "POST" ""
+  assert "${root}/dynamic/timeout.cgi" "504" "GET" ""
 
   # DELETE
   assert "${root}/dynamic/post_cgi.py" "405" "DELETE" ""
@@ -138,6 +141,7 @@ function runTest {
   assert "${root}/dynamic/client_redirect_res.cgi" "302" "DELETE" ""
   assert "${root}/dynamic/client_redirect_res_doc.cgi" "302" "DELETE" ""
   assert "${root}/dynamic/body_res.py" "200" "DELETE" ""
+  assert "${root}/dynamic/timeout.cgi" "504" "GET" ""
 
   # サーバープロセスを終了
   kill ${webserv_pid} >/dev/null 2>&1

--- a/test/integration_test/test_files/server_res_test/dynamic/timeout.py
+++ b/test/integration_test/test_files/server_res_test/dynamic/timeout.py
@@ -1,4 +1,4 @@
 #!/usr/bin/python3
 
 while True:
-  pass
+    pass

--- a/test/integration_test/test_files/server_res_test/dynamic/timeout.py
+++ b/test/integration_test/test_files/server_res_test/dynamic/timeout.py
@@ -1,0 +1,4 @@
+#!/usr/bin/python3
+
+while True:
+  pass

--- a/test/integration_test/test_files/server_res_test/server_res_test.conf
+++ b/test/integration_test/test_files/server_res_test/server_res_test.conf
@@ -1,6 +1,7 @@
 events {}
 
 http{
+  receive_timeout 2s;
 	server{
 		root ./;
 		listen 4242;

--- a/test/integration_test/test_files/server_res_test/server_res_test_poll.conf
+++ b/test/integration_test/test_files/server_res_test/server_res_test_poll.conf
@@ -3,6 +3,7 @@ events {
 }
 
 http{
+  receive_timeout 2s;
 	server{
 		root ./;
 		listen 4242;

--- a/test/integration_test/test_files/server_res_test/server_res_test_select.conf
+++ b/test/integration_test/test_files/server_res_test/server_res_test_select.conf
@@ -3,6 +3,7 @@ events {
 }
 
 http{
+  receive_timeout 2s;
 	server{
 		root ./;
 		listen 4242;


### PR DESCRIPTION
killするときに送るシグナルをSIGKILLからSIGTERMに変更しました。これはtestの中でwebservがSIGKILLだとうまく子プロセスをkillできていなかったからです。
これは不確かですが、SIGKILLは端末が紐づけられていないと機能しないのかもしれません。
Linuxプログラミングインターフェースを読む限りでもSIGTERMの方がプロセスをkillするシグナルとしては一般的なようです。

timeoutしたのがcgiだった場合に、killしたプロセスをwaitして回収するようにしました。
いまはhandleTimeoutEventの方だけで行っているのですが、本来はworker_connectionsでプロセスをkillしたときも回収しないとなので、ほかのところでまとめてwaitpidするように変更するかもしれません。例えばServerのloopの最後とか？
そのプロセスが少しオーバーヘッドを生み出しそうで懸念しています。

504エラーレスポンスが返せていなかったので返すようにしました。
server_res_testにもcgiがタイムアウトしたときに504を返すテストを追加しました。