### PR TITLE
Issue267 handle no host header

### DIFF
--- a/src/config/LimitExcept.hpp
+++ b/src/config/LimitExcept.hpp
@@ -32,7 +32,7 @@ struct LimitExcept {
     return *this;
   }
   static std::string MethodToStr(const REQUEST_METHOD method) {
-    std::string re;
+    std::string re = "";
     switch (method) {
       case GET:
         re = "GET";

--- a/src/http/HttpResponse.cpp
+++ b/src/http/HttpResponse.cpp
@@ -372,6 +372,9 @@ std::string HttpResponse::generateResponse(HttpRequest& request, HttpResponse& r
   // chunkなどでparse途中の場合。
   if (request.parse_state_ == HttpRequest::PARSE_INPROGRESS) return std::string();
 
+  if (request.headers_.find(kHost) == request.headers_.end()) {
+    return handleNoHost(response, request);
+  }
   const config::Server& server =
       config_handler.searchServerConfig(tied_servers, request.headers_.find(kHost)->second);
   const config::Location* location = NULL;
@@ -458,6 +461,15 @@ std::string HttpResponse::generateResponse(HttpRequest& request, HttpResponse& r
   config_handler.writeErrorLog("create final response", config::DEBUG);
   config_handler.writeErrorLog("final response file path " + response.res_file_path_, config::DEBUG);
   response.state_ = RES_COMPLETE;
+  return response.createResponse(request.method_);
+}
+
+std::string HttpResponse::handleNoHost(HttpResponse& response, HttpRequest& request) {
+  response.setStatusCode(400);
+  if (default_error_page_map_.find(response.getStatusCode()) != default_error_page_map_.end()) {
+    response.res_file_path_ = kDefaultPage;
+    response.body_ = std::string(default_error_page_map_[response.getStatusCode()]) + webserv_error_page_tail;
+  }
   return response.createResponse(request.method_);
 }
 

--- a/src/http/HttpResponse.cpp
+++ b/src/http/HttpResponse.cpp
@@ -372,6 +372,7 @@ std::string HttpResponse::generateResponse(HttpRequest& request, HttpResponse& r
   // chunkなどでparse途中の場合。
   if (request.parse_state_ == HttpRequest::PARSE_INPROGRESS) return std::string();
 
+  // requestにホストヘッダーがない時は、以降の処理を通すために空のホストヘッダーを追加する。
   if (request.headers_.find(kHost) == request.headers_.end()) {
     request.headers_[kHost] = "";
   }

--- a/src/http/HttpResponse.cpp
+++ b/src/http/HttpResponse.cpp
@@ -372,7 +372,9 @@ std::string HttpResponse::generateResponse(HttpRequest& request, HttpResponse& r
   // chunkなどでparse途中の場合。
   if (request.parse_state_ == HttpRequest::PARSE_INPROGRESS) return std::string();
 
-  // requestにホストヘッダーがない時は、以降の処理を通すために空のホストヘッダーを追加する。
+  // requestにホストヘッダーがない時は、空文字のホストヘッダーを追加する。
+  // この場合、まずserver_nameが空文字列のサーバーが適用される。
+  // それがなければ、デフォルトサーバーの設定が適用される。
   if (request.headers_.find(kHost) == request.headers_.end()) {
     request.headers_[kHost] = "";
   }

--- a/src/http/HttpResponse.hpp
+++ b/src/http/HttpResponse.hpp
@@ -59,6 +59,7 @@ class HttpResponse {
 
  private:
   std::string createResponse(config::REQUEST_METHOD method) const;
+  static std::string handleNoHost(HttpResponse& response, HttpRequest& request);
   static ResponsePhase handlePreSearchLocationPhase(HttpRequest::ParseState parse_state,
                                                     HttpResponse& response, int socket,
                                                     struct sockaddr_in& client_addr);

--- a/src/http/HttpResponse.hpp
+++ b/src/http/HttpResponse.hpp
@@ -59,8 +59,6 @@ class HttpResponse {
 
  private:
   std::string createResponse(config::REQUEST_METHOD method) const;
-  static std::string handleNoHost(HttpResponse& response, HttpRequest& request, int socket,
-                                  const ConfigHandler& config_handler);
   static ResponsePhase handlePreSearchLocationPhase(HttpRequest::ParseState parse_state,
                                                     HttpResponse& response, int socket,
                                                     struct sockaddr_in& client_addr);

--- a/src/http/HttpResponse.hpp
+++ b/src/http/HttpResponse.hpp
@@ -59,7 +59,8 @@ class HttpResponse {
 
  private:
   std::string createResponse(config::REQUEST_METHOD method) const;
-  static std::string handleNoHost(HttpResponse& response, HttpRequest& request);
+  static std::string handleNoHost(HttpResponse& response, HttpRequest& request, int socket,
+                                  const ConfigHandler& config_handler);
   static ResponsePhase handlePreSearchLocationPhase(HttpRequest::ParseState parse_state,
                                                     HttpResponse& response, int socket,
                                                     struct sockaddr_in& client_addr);

--- a/src/server/ConfigHandler.cpp
+++ b/src/server/ConfigHandler.cpp
@@ -118,11 +118,11 @@ int ConfigHandler::allowRequest(const config::Server& server, const config::Loca
 }
 
 // 最終的なlocationで記録
-void ConfigHandler::writeAccessLog(const struct TiedServer& tied_servers, const std::string& server_name,
-                                   const std::string& uri, const std::string& msg) const {
-  const config::Server& server = searchServerConfig(tied_servers, server_name);
-  const config::Location* location = searchLongestMatchLocationConfig(server, uri);
-  writeAccessLog(server, location, msg);
+void ConfigHandler::writeAccessLog(const std::string& msg) const {
+  for (size_t i = 0; i < this->config_->http_.access_log_list_.size(); i++) {
+    if (utils::writeChunks(this->config_->http_.access_log_list_[i].getFd(), msg) == -1)
+      WebServer::writeErrorlog(error::strSysCallError("write"), config::ERROR);
+  }
 }
 
 void ConfigHandler::writeAccessLog(const config::Server& server, const config::Location* location,

--- a/src/server/ConfigHandler.hpp
+++ b/src/server/ConfigHandler.hpp
@@ -26,8 +26,7 @@ class ConfigHandler {
   int allowRequest(const config::Server& server, const config::Location* location, const HttpRequest& request,
                    struct sockaddr_in client_addr) const;
   // log出力
-  void writeAccessLog(const struct TiedServer& tied_servers, const std::string& server_name,
-                      const std::string& uri, const std::string& msg) const;
+  void writeAccessLog(const std::string& msg) const;
   void writeAccessLog(const config::Server& server, const config::Location* location,
                       const std::string& msg) const;
   void writeErrorLog(const struct TiedServer& tied_servers, const std::string& server_name,

--- a/src/server/ConfigHandler.hpp
+++ b/src/server/ConfigHandler.hpp
@@ -26,9 +26,11 @@ class ConfigHandler {
   int allowRequest(const config::Server& server, const config::Location* location, const HttpRequest& request,
                    struct sockaddr_in client_addr) const;
   // log出力
-  void writeAccessLog(const std::string& msg) const;
+  void writeAccessLog(const struct TiedServer& tied_servers, const std::string& server_name,
+                      const std::string& uri, const std::string& msg) const;
   void writeAccessLog(const config::Server& server, const config::Location* location,
                       const std::string& msg) const;
+  void writeAccessLog(const std::string& msg) const;
   void writeErrorLog(const struct TiedServer& tied_servers, const std::string& server_name,
                      const std::string& uri, const std::string& msg, config::LOG_LEVEL level) const;
   void writeErrorLog(const config::Server& server, const config::Location* location, const std::string& msg,

--- a/src/server/EventHandler.cpp
+++ b/src/server/EventHandler.cpp
@@ -330,8 +330,7 @@ void EventHandler::addTimerByType(ConnectionManager &conn_manager, const ConfigH
   std::map<std::string, std::string>::iterator it;
 
   // Hostヘッダーがあるか確認
-  // 400エラーがerror_pageで拾われて内部リダイレクトする可能性があるので以下の処理は必要。
-  // このように探すdirectiveがほんとにこのクライアントが最後にアクセスしたコンテキストかは怪しい。
+  // requestを処理する前にreceive_timeoutをセットするのでこの処理は必要。
   it = conn_manager.getRequest(sock).headers_.find("Host");
   std::string host_name;
   if (it == conn_manager.getRequest(sock).headers_.end())

--- a/test/integration_test/server_res_test.sh
+++ b/test/integration_test/server_res_test.sh
@@ -83,6 +83,7 @@ function runTest {
   local root="test/integration_test/test_files/server_res_test"
   local conf=$1
   local server_name=$2
+  local random_string=$(openssl rand -base64 1024 | tr -dc 'a-zA-Z0-9' | head -c 1024)
   g_test_index=0
 
   runServer "${root}/${conf}"
@@ -102,8 +103,10 @@ function runTest {
   assert "${root}/dynamic/client_redirect_res_doc.cgi" "302" "GET" ""
   assert "${root}/dynamic/body_res.py" "200" "GET" ""
   assert "${root}/dynamic/post_cgi.py?key=value" "200" "GET" ""
+
   # HEAD
   assert "${root}/static/index.html" "200" "HEAD" ""
+  assert "${root}/static/index.html" "400" "HEAD" "-H Host:"
   assert "${root}/static/nonexist" "404" "HEAD" ""
   assert "${root}/dynamic/post_cgi.py?key=value" "200" "HEAD" ""
   assert "${root}/dynamic/exit_non_zero.cgi" "500" "GET" ""
@@ -117,6 +120,7 @@ function runTest {
 
   # POST
   assert "${root}/dynamic/post_cgi.py" "200" "POST" "-d key=value"
+  assert "${root}/static/index.html" "400" "POST" "-H Host:"
   assert "${root}/dynamic/post_cgi.py" "400" "POST" "-d invalid=value"
   assert "${root}/static/index.html" "405" "POST" ""
   assert "${root}/dynamic/post_cgi.py" "400" "POST" "-d ''"
@@ -127,9 +131,11 @@ function runTest {
   assert "${root}/dynamic/client_redirect_res.cgi" "302" "POST" ""
   assert "${root}/dynamic/client_redirect_res_doc.cgi" "302" "POST" ""
   assert "${root}/dynamic/body_res.py" "200" "POST" ""
+  assert "${root}/dynamic/body_res.py" "413" "POST" "-d \"${random_string}\""
 
   # DELETE
   assert "${root}/dynamic/post_cgi.py" "405" "DELETE" ""
+  assert "${root}/static/index.html" "400" "DELETE" "-H Host:"
   assert "${root}/static/index.html" "405" "DELETE" ""
   assert "${root}/dynamic/exit_non_zero.cgi" "500" "DELETE" ""
   assert "${root}/dynamic/parse_error.py" "502" "DELETE" ""
@@ -138,6 +144,10 @@ function runTest {
   assert "${root}/dynamic/client_redirect_res.cgi" "302" "DELETE" ""
   assert "${root}/dynamic/client_redirect_res_doc.cgi" "302" "DELETE" ""
   assert "${root}/dynamic/body_res.py" "200" "DELETE" ""
+  assert "${root}/dynamic/body_res.py" "413" "POST" "-d \"${random_string}\""
+
+  # UNKNOWN
+  assert "${root}/static/index.html" "400" "UNKNOWN" ""
 
   # サーバープロセスを終了
   kill ${webserv_pid} >/dev/null 2>&1

--- a/test/integration_test/server_res_test.sh
+++ b/test/integration_test/server_res_test.sh
@@ -103,6 +103,7 @@ function runTest {
   assert "${root}/dynamic/client_redirect_res_doc.cgi" "302" "GET" ""
   assert "${root}/dynamic/body_res.py" "200" "GET" ""
   assert "${root}/dynamic/post_cgi.py?key=value" "200" "GET" ""
+  assert "${root}/dynamic/body_res.py" "413" "GET" "-d \"${random_string}\""
 
   # HEAD
   assert "${root}/static/index.html" "200" "HEAD" ""
@@ -144,7 +145,7 @@ function runTest {
   assert "${root}/dynamic/client_redirect_res.cgi" "302" "DELETE" ""
   assert "${root}/dynamic/client_redirect_res_doc.cgi" "302" "DELETE" ""
   assert "${root}/dynamic/body_res.py" "200" "DELETE" ""
-  assert "${root}/dynamic/body_res.py" "413" "POST" "-d \"${random_string}\""
+  assert "${root}/dynamic/body_res.py" "413" "DELETE" "-d \"${random_string}\""
 
   # UNKNOWN
   assert "${root}/static/index.html" "400" "UNKNOWN" ""

--- a/test/integration_test/test_files/server_res_test/server_res_test.conf
+++ b/test/integration_test/test_files/server_res_test/server_res_test.conf
@@ -1,6 +1,7 @@
 events {}
 
 http{
+  client_max_body_size 1k;
 	server{
 		root ./;
 		listen 4242;

--- a/test/integration_test/test_files/server_res_test/server_res_test_poll.conf
+++ b/test/integration_test/test_files/server_res_test/server_res_test_poll.conf
@@ -3,6 +3,7 @@ events {
 }
 
 http{
+  client_max_body_size 1k;
 	server{
 		root ./;
 		listen 4242;

--- a/test/integration_test/test_files/server_res_test/server_res_test_select.conf
+++ b/test/integration_test/test_files/server_res_test/server_res_test_select.conf
@@ -3,6 +3,7 @@ events {
 }
 
 http{
+  client_max_body_size 1k;
 	server{
 		root ./;
 		listen 4242;


### PR DESCRIPTION
ホストヘッダーがない時にgenerateResponse()の始めに空のホストヘッダーをつけることにしました。

- 以下のテストケースを追加しました。
ホストヘッダーが空のテストケースをＧＥＴ以外のメソッドにも追加しました。
413エラーのテストケースをGETとPOSTとDELETEに追加しました。
UNKNOWNメソッドを追加しました。