### PR TITLE
Issue273 bug unreset raw request

### DIFF
--- a/src/http/HttpRequest.cpp
+++ b/src/http/HttpRequest.cpp
@@ -50,7 +50,7 @@ HttpRequest &HttpRequest::operator=(const HttpRequest &other) {
 void HttpRequest::parseRequest(std::string &raw_request, HttpRequest &request) {
   // 新たなリクエストの場合は初期化する
   if (!isParsePending(request)) {
-     HttpRequest::clear(request);
+    HttpRequest::clear(request);
   }
   ParseState &state = request.parse_state_;
   while (state != PARSE_COMPLETE) {
@@ -77,8 +77,7 @@ void HttpRequest::parseRequest(std::string &raw_request, HttpRequest &request) {
       default:
         break;
     }
-    // PARSE_NOT_IMPLEMENTEDは条件に入らなくていいのか？
-    if (state == PARSE_ERROR || state == PARSE_ERROR_BODY_TOO_LARGE) return;
+    if (state == PARSE_ERROR || state == PARSE_ERROR_BODY_TOO_LARGE || state == PARSE_NOT_IMPLEMENTED) return;
     // parse未完了：引き続きクライアントからのrequestを待つ
     if (state == state_before || state == PARSE_INPROGRESS) return;
   }

--- a/src/http/HttpRequest.cpp
+++ b/src/http/HttpRequest.cpp
@@ -49,7 +49,9 @@ HttpRequest &HttpRequest::operator=(const HttpRequest &other) {
 
 void HttpRequest::parseRequest(std::string &raw_request, HttpRequest &request) {
   // 新たなリクエストの場合は初期化する
-  if (request.parse_state_ == PARSE_COMPLETE) HttpRequest::clear(request);
+  if (!isParsePending(request)) {
+     HttpRequest::clear(request);
+  }
   ParseState &state = request.parse_state_;
   while (state != PARSE_COMPLETE) {
     ParseState state_before = state;
@@ -75,6 +77,7 @@ void HttpRequest::parseRequest(std::string &raw_request, HttpRequest &request) {
       default:
         break;
     }
+    // PARSE_NOT_IMPLEMENTEDは条件に入らなくていいのか？
     if (state == PARSE_ERROR || state == PARSE_ERROR_BODY_TOO_LARGE) return;
     // parse未完了：引き続きクライアントからのrequestを待つ
     if (state == state_before || state == PARSE_INPROGRESS) return;

--- a/test/integration_test/multiple_requests_test.py
+++ b/test/integration_test/multiple_requests_test.py
@@ -83,6 +83,7 @@ def test(conf):
             + f"GET /{ROOT}/index.html HTTP/1.1\nhost:tt\n\n"
             + f"GET /{ROOT}/index.py HTTP/1.1\nhost:tt\ntransfer-encoding: chunked\n\nd\nthis is body.\n0\n\n",  # d is 13 bytes in hex
             # three requests test
+            f"GET /{ROOT}/index.html HTTP/1.1\nhost:tt\ntransfer-encoding:zip\n\nDELETE ",
         ],
         EXPECTS: [
             [200, 302],
@@ -94,6 +95,7 @@ def test(conf):
             [200],
             [404],
             [302, 200, 302],
+            [501],
         ],
         CONNECTION: [
             ALIVE,
@@ -104,6 +106,7 @@ def test(conf):
             ALIVE,
             ALIVE,
             CLOSE,
+            ALIVE,
             ALIVE,
         ],
         ADDRESS: "127.0.0.1",


### PR DESCRIPTION
PARSE_NOT_IMPLEMENTEDのときに複数リクエストを送ると、無限に５０１レスポンスが返ってきてしまっていたので、それを修正しました。

parseRequestの冒頭で、isParsePending()でないときにリクエストをリセットするようにしました。