### PR TITLE
Issue279 replace with alias

### DIFF
--- a/test/server/HttpResponse/alias/alias_test.cpp
+++ b/test/server/HttpResponse/alias/alias_test.cpp
@@ -45,6 +45,24 @@ TEST(HttpResponseAlias, server_index) {
   test.testResponse(test.createResponse(HttpResponse::status_line_map_[200]));
 }
 
+TEST(HttpResponseAlias, replace_root_with_alias) {
+  test::ResponseTest test("test/server/HttpResponse/alias/file/alias.conf");
+  ASSERT_NO_FATAL_FAILURE(test.setUpAll(
+      {{"127.0.0.1", 4242}, {"127.0.0.1", 4243}}, {{"host", "test"}, {"User-Agent", "Mozilla/5.0"}},
+      {config::REQUEST_METHOD::GET}, "/alias1/loc1.html", HttpRequest::PARSE_COMPLETE));
+
+  const std::string expect_body = utils::readFile("test/server/HttpResponse/alias/alias_dir/loc1.html");
+  test.testHeaders({
+      {"Server", "webserv/1.0"},
+      {"Date", ""},
+      {"Content-Length", std::to_string(expect_body.size())},
+      {"Content-Type", "text/html"},
+      {"Connection", "keep-alive"},
+  });
+  test.testBody(expect_body);
+  test.testResponse(test.createResponse(HttpResponse::status_line_map_[200]));
+}
+
 TEST(HttpResponseAlias, location_index_dir_listing) {
   test::ResponseTest test("test/server/HttpResponse/alias/file/alias.conf");
   ASSERT_NO_FATAL_FAILURE(test.setUpAll(


### PR DESCRIPTION
request uriがファイルパスである時に、location uriの部分をaliasに差し替えるようにしました。

```
ex)
listen4242;
locatino /alias/ {
   alias test;
}


localhost:4242/alias/index.html
↓
localhost:4242/test/index.html
```